### PR TITLE
Search endpoint bug fix, and client updates

### DIFF
--- a/src/mp_api/matproj.py
+++ b/src/mp_api/matproj.py
@@ -173,7 +173,9 @@ class MPRester:
 
     def has(self, mpid):
         # TODO: remove, here until search end-point has a client
-        return self.materials.session.get(urljoin(self.endpoint, f"search/{mpid}/?fields=has_props")).json()['data'][0]['has_props']
+        return self.materials.session.get(
+            urljoin(self.endpoint, f"search/{mpid}/?fields=has_props")
+        ).json()["data"][0]["has_props"]
 
     ###########################################################################
     # The following methods are retained for backwards compatibility, but will

--- a/src/mp_api/phonon/resources.py
+++ b/src/mp_api/phonon/resources.py
@@ -1,4 +1,5 @@
 import io
+from fastapi.exceptions import HTTPException
 from fastapi.param_functions import Path
 from fastapi.responses import StreamingResponse
 
@@ -43,7 +44,16 @@ def phonon_img_resource(phonon_img_store):
 
             self.store.connect()
 
-            img = self.store.query_one(criteria=crit, properties=["plot"])["plot"]
+            img = self.store.query_one(criteria=crit, properties=["plot"])
+
+            if img is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No image found for {task_id}.",
+                )
+
+            else:
+                img = img["plot"]
 
             response = StreamingResponse(
                 io.BytesIO(img),

--- a/src/mp_api/phonon/resources.py
+++ b/src/mp_api/phonon/resources.py
@@ -49,7 +49,7 @@ def phonon_img_resource(phonon_img_store):
                 io.BytesIO(img),
                 media_type="img/png",
                 headers={
-                    "Content-Disposition": "inline; filename='{}_phonon_bs'.png".format(
+                    "Content-Disposition": 'inline; filename="{}_phonon_bs.png"'.format(
                         task_id
                     )
                 },

--- a/src/mp_api/search/query_operators.py
+++ b/src/mp_api/search/query_operators.py
@@ -132,6 +132,90 @@ class SearchBandGapQuery(QueryOperator):
         return {"criteria": crit}
 
 
+class ThermoEnergySearchQuery(QueryOperator):
+    """
+    Method to generate a query for ranges of thermo energy data in search docs
+    """
+
+    def query(
+        self,
+        energy_max: Optional[float] = Query(
+            None,
+            description="Maximum value for the total energy in eV.",
+        ),
+        energy_min: Optional[float] = Query(
+            None,
+            description="Minimum value for the total energy in eV.",
+        ),
+        energy_per_atom_max: Optional[float] = Query(
+            None,
+            description="Maximum value for the total energy in eV/atom.",
+        ),
+        energy_per_atom_min: Optional[float] = Query(
+            None,
+            description="Minimum value for the total energy in eV/atom.",
+        ),
+        formation_energy_per_atom_max: Optional[float] = Query(
+            None,
+            description="Maximum value for the formation energy in eV/atom.",
+        ),
+        formation_energy_per_atom_min: Optional[float] = Query(
+            None,
+            description="Minimum value for the formation energy in eV/atom.",
+        ),
+        e_above_hull_max: Optional[float] = Query(
+            None,
+            description="Maximum value for the energy above the hull in eV/atom.",
+        ),
+        e_above_hull_min: Optional[float] = Query(
+            None,
+            description="Minimum value for the energy above the hull in eV/atom.",
+        ),
+        eq_reaction_max: Optional[float] = Query(
+            None,
+            description="Maximum value for the equilibrium reaction energy in eV/atom.",
+        ),
+        eq_reaction_min: Optional[float] = Query(
+            None,
+            description="Minimum value for the equilibrium reaction energy in eV/atom.",
+        ),
+        corrected_energy_max: Optional[float] = Query(
+            None,
+            description="Maximum value for the corrected total energy in eV.",
+        ),
+        corrected_energy_min: Optional[float] = Query(
+            None,
+            description="Minimum value for the corrected total energy in eV.",
+        ),
+    ) -> STORE_PARAMS:
+
+        crit = defaultdict(dict)  # type: dict
+
+        d = {
+            "energy": [energy_min, energy_max],
+            "energy_per_atom": [energy_per_atom_min, energy_per_atom_max],
+            "formation_energy_per_atom": [
+                formation_energy_per_atom_min,
+                formation_energy_per_atom_max,
+            ],
+            "e_above_hull": [e_above_hull_min, e_above_hull_max],
+            "eq_reaction_e": [eq_reaction_min, eq_reaction_max],
+            "explanation.corrected_energy": [
+                corrected_energy_min,
+                corrected_energy_max,
+            ],
+        }
+
+        for entry in d:
+            if d[entry][0] is not None:
+                crit[entry]["$gte"] = d[entry][0]
+
+            if d[entry][1] is not None:
+                crit[entry]["$lte"] = d[entry][1]
+
+        return {"criteria": crit}
+
+
 # TODO:
 # XAS and GB sub doc query operators
 # Magnetism query ops from endpoint

--- a/src/mp_api/search/resources.py
+++ b/src/mp_api/search/resources.py
@@ -8,7 +8,7 @@ from mp_api.materials.query_operators import (
     SymmetryQuery,
     DeprecationQuery,
 )
-from mp_api.thermo.query_operators import IsStableQuery, ThermoEnergyQuery
+from mp_api.thermo.query_operators import IsStableQuery
 from mp_api.elasticity.query_operators import (
     BulkModulusQuery,
     ShearModulusQuery,
@@ -17,7 +17,11 @@ from mp_api.elasticity.query_operators import (
 from mp_api.dielectric.query_operators import DielectricQuery
 from mp_api.piezo.query_operators import PiezoelectricQuery
 from mp_api.surface_properties.query_operators import SurfaceMinMaxQuery
-from mp_api.search.query_operators import SearchBandGapQuery, HasPropsQuery
+from mp_api.search.query_operators import (
+    SearchBandGapQuery,
+    HasPropsQuery,
+    ThermoEnergySearchQuery,
+)
 
 
 def search_resource(eos_store):
@@ -28,7 +32,7 @@ def search_resource(eos_store):
             FormulaQuery(),
             MinMaxQuery(),
             SymmetryQuery(),
-            ThermoEnergyQuery(),
+            ThermoEnergySearchQuery(),
             IsStableQuery(),
             SearchBandGapQuery(),
             BulkModulusQuery(),


### PR DESCRIPTION
This PR contains:

- Added a custom thermo energy query operator for the search endpoint to allow for top level searching of energy data.
- Materials client returns individual documents in each chunk requested instead of full chunk
- Additional routes added to mass MPRester class