### PR TITLE
Multiple task_id query added to search

### DIFF
--- a/src/mp_api/matproj.py
+++ b/src/mp_api/matproj.py
@@ -173,7 +173,9 @@ class MPRester:
 
     def has(self, mpid):
         # TODO: remove, here until search end-point has a client
-        return self.materials.session.get(urljoin(self.endpoint, f"search/{mpid}/?fields=has_props")).json()['data'][0]['has_props']
+        return self.materials.session.get(
+            urljoin(self.endpoint, f"search/{mpid}/?fields=has_props")
+        ).json()["data"][0]["has_props"]
 
     ###########################################################################
     # The following methods are retained for backwards compatibility, but will

--- a/src/mp_api/search/client.py
+++ b/src/mp_api/search/client.py
@@ -1,0 +1,5 @@
+from mp_api.core.client import BaseRester
+
+
+class SearchRester(BaseRester):
+    suffix = "search"

--- a/src/mp_api/search/client.py
+++ b/src/mp_api/search/client.py
@@ -1,6 +1,0 @@
-from mp_api.core.client import BaseRester
-
-
-class SearchRester(BaseRester):
-
-    suffix = "search"

--- a/src/mp_api/search/query_operators.py
+++ b/src/mp_api/search/query_operators.py
@@ -216,6 +216,26 @@ class ThermoEnergySearchQuery(QueryOperator):
         return {"criteria": crit}
 
 
+class SearchTaskIDsQuery(QueryOperator):
+    """
+    Method to generate a query on search docs using multiple task_id values
+    """
+
+    def query(
+        self,
+        task_ids: Optional[str] = Query(
+            None, description="Comma-separated list of task_ids to query on"
+        ),
+    ) -> STORE_PARAMS:
+
+        crit = {}
+
+        if task_ids:
+            crit.update({"task_id": {"$in": task_ids.split(",")}})
+
+        return {"criteria": crit}
+
+
 # TODO:
 # XAS and GB sub doc query operators
 # Magnetism query ops from endpoint

--- a/src/mp_api/search/resources.py
+++ b/src/mp_api/search/resources.py
@@ -21,6 +21,7 @@ from mp_api.search.query_operators import (
     SearchBandGapQuery,
     HasPropsQuery,
     ThermoEnergySearchQuery,
+    SearchTaskIDsQuery,
 )
 
 
@@ -41,6 +42,7 @@ def search_resource(eos_store):
             DielectricQuery(),
             PiezoelectricQuery(),
             SurfaceMinMaxQuery(),
+            SearchTaskIDsQuery(),
             HasPropsQuery(),
             DeprecationQuery(),
             PaginationQuery(),

--- a/src/mp_api/thermo/query_operators.py
+++ b/src/mp_api/thermo/query_operators.py
@@ -58,7 +58,7 @@ class IsStableQuery(QueryOperator):
 
         crit = {}
 
-        if is_stable:
+        if is_stable is not None:
             crit["is_stable"] = is_stable
 
         return {"criteria": crit}


### PR DESCRIPTION
This PR contains:

- Fix to `is_stable` query operator
- Added ability to query search endpoint using multiple task_ids