### PR TITLE
Version query bug fix

### DIFF
--- a/src/mp_api/core/client.py
+++ b/src/mp_api/core/client.py
@@ -321,7 +321,7 @@ class BaseRester:
         return (
             f"{self.__class__.__name__} connected to {self.endpoint}\n"
             f"Available fields: {', '.join(self.available_fields)}\n"
-            f"Available documents: {self.count():n}"
+            f"Available documents: {self.count()}"
         )
 
 

--- a/src/mp_api/core/resource.py
+++ b/src/mp_api/core/resource.py
@@ -217,10 +217,10 @@ class Resource(MSONable):
 
                 if version is not None:
                     version = version.replace(".", "_")
-                    self.store.collection_name = (
-                        f"{self.store.collection_name}_{version}"
-                    )
-                self.store.connect()
+                    prefix = self.store.collection_name.split("_")[0]
+                    self.store.collection_name = f"{prefix}_{version}"
+
+                self.store.connect(force_reset=True)
 
                 crit = {self.store.key: key}
 
@@ -282,10 +282,11 @@ class Resource(MSONable):
 
             if self.versioned and query["criteria"].get("version", None) is not None:
                 version = query["criteria"]["version"].replace(".", "_")
-                self.store.collection_name = f"{self.store.collection_name}_{version}"
+                prefix = self.store.collection_name.split("_")[0]
+                self.store.collection_name = f"{prefix}_{version}"
                 query["criteria"].pop("version")
 
-            self.store.connect()
+            self.store.connect(force_reset=True)
 
             if model_name == "MaterialsCoreDoc":
                 query["criteria"].update({"_sbxn": "core"})


### PR DESCRIPTION
This PR fixes a bug with querying data from versioned endpoints. The default database version is pulled for every query to avoid incorrect collection naming. 