### PR TITLE
Fix total_doc synth population

### DIFF
--- a/src/mp_api/routes/synthesis/query_operators.py
+++ b/src/mp_api/routes/synthesis/query_operators.py
@@ -160,7 +160,10 @@ class SynthesisSearchQuery(QueryOperator):
             }
 
         if crit:
-            pipeline[-1]["$facet"]["results"].append({"$match": crit})
+            if keywords:
+                pipeline.insert(1, {"$match": crit})
+            else:
+                pipeline.insert(0, {"$match": crit})
 
         pipeline[-1]["$facet"]["total_doc"].append({"$count": "count"})
         pipeline.extend(

--- a/tests/synthesis/test_query_operators.py
+++ b/tests/synthesis/test_query_operators.py
@@ -13,6 +13,19 @@ def test_synthesis_search_query():
         pipeline = (
             [
                 {
+                    "$match": {
+                        "synthesis_type": {"$in": ["solid-state"]},
+                        "targets_formula_s": "SiO2",
+                        "precursors_formula_s": "SiO2",
+                        "operations.type": {"$all": ["ShapingOperation"]},
+                        "operations.conditions.heating_temperature.values": {"$lte": 5},
+                        "operations.conditions.heating_time.values": {"$lte": 5},
+                        "operations.conditions.heating_atmosphere": {"$all": "air"},
+                        "operations.conditions.mixing_device": {"$all": "zirconia"},
+                        "operations.conditions.mixing_media": {"$all": "water"},
+                    }
+                },
+                {
                     "$facet": {
                         "results": [
                             {"$skip": 0},
@@ -31,29 +44,6 @@ def test_synthesis_search_query():
                                     "precursors": 1,
                                     "precursors_formula_s": 1,
                                     "paragraph_string": 1,
-                                }
-                            },
-                            {
-                                "$match": {
-                                    "synthesis_type": {"$in": ["solid-state"]},
-                                    "targets_formula_s": "SiO2",
-                                    "precursors_formula_s": "SiO2",
-                                    "operations.type": {"$all": ["ShapingOperation"]},
-                                    "operations.conditions.heating_temperature.values": {
-                                        "$lte": 5
-                                    },
-                                    "operations.conditions.heating_time.values": {
-                                        "$lte": 5
-                                    },
-                                    "operations.conditions.heating_atmosphere": {
-                                        "$all": "air"
-                                    },
-                                    "operations.conditions.mixing_device": {
-                                        "$all": "zirconia"
-                                    },
-                                    "operations.conditions.mixing_media": {
-                                        "$all": "water"
-                                    },
                                 }
                             },
                         ],
@@ -86,6 +76,19 @@ def test_synthesis_search_query():
                     }
                 },
                 {
+                    "$match": {
+                        "synthesis_type": {"$in": ["solid-state"]},
+                        "targets_formula_s": "SiO2",
+                        "precursors_formula_s": "SiO2",
+                        "operations.type": {"$all": ["ShapingOperation"]},
+                        "operations.conditions.heating_temperature.values": {"$lte": 5},
+                        "operations.conditions.heating_time.values": {"$lte": 5},
+                        "operations.conditions.heating_atmosphere": {"$all": "air"},
+                        "operations.conditions.mixing_device": {"$all": "zirconia"},
+                        "operations.conditions.mixing_media": {"$all": "water"},
+                    }
+                },
+                {
                     "$facet": {
                         "results": [
                             {
@@ -104,29 +107,6 @@ def test_synthesis_search_query():
                                     "paragraph_string": 1,
                                     "search_score": {"$meta": "searchScore"},
                                     "highlights": {"$meta": "searchHighlights"},
-                                }
-                            },
-                            {
-                                "$match": {
-                                    "synthesis_type": {"$in": ["solid-state"]},
-                                    "targets_formula_s": "SiO2",
-                                    "precursors_formula_s": "SiO2",
-                                    "operations.type": {"$all": ["ShapingOperation"]},
-                                    "operations.conditions.heating_temperature.values": {
-                                        "$lte": 5
-                                    },
-                                    "operations.conditions.heating_time.values": {
-                                        "$lte": 5
-                                    },
-                                    "operations.conditions.heating_atmosphere": {
-                                        "$all": "air"
-                                    },
-                                    "operations.conditions.mixing_device": {
-                                        "$all": "zirconia"
-                                    },
-                                    "operations.conditions.mixing_media": {
-                                        "$all": "water"
-                                    },
                                 }
                             },
                         ],


### PR DESCRIPTION
This PR fixes the bug mentioned in issue #309 with `total_doc` population when filters are included in addition to keywords. 