### PR TITLE
Enable direct response on appropriate endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==1.8.2
 pymatgen==2022.0.10
 typing-extensions==3.10.0.0
-maggma==0.29.4
+maggma==0.30.0
 requests==2.25.1
 monty==2021.6.10
 emmet-core==0.5.0

--- a/src/mp_api/routes/charge_density/resources.py
+++ b/src/mp_api/routes/charge_density/resources.py
@@ -11,11 +11,14 @@ def charge_density_resource(s3_store):
         query_operators=[
             ChgcarTaskIDQuery(),
             PaginationQuery(default_limit=5, max_limit=10),
-            SparseFieldsQuery(ChgcarDataDoc, default_fields=["task_id", "last_updated"],),
+            SparseFieldsQuery(
+                ChgcarDataDoc, default_fields=["task_id", "last_updated"],
+            ),
         ],
         tags=["Charge Density"],
         enable_default_search=True,
         enable_get_by_key=False,
+        monty_encoded_response=True,
     )
 
     return resource

--- a/src/mp_api/routes/electrodes/resources.py
+++ b/src/mp_api/routes/electrodes/resources.py
@@ -26,6 +26,7 @@ def insertion_electrodes_resource(insertion_electrodes_store):
             ),
         ],
         tags=["Electrodes"],
+        monty_encoded_response=True,
     )
 
     return resource

--- a/src/mp_api/routes/electronic_structure/resources.py
+++ b/src/mp_api/routes/electronic_structure/resources.py
@@ -71,6 +71,7 @@ def bs_obj_resource(s3_store):
         enable_get_by_key=False,
         enable_default_search=True,
         sub_path="/bandstructure/object/",
+        monty_encoded_response=True,
     )
     return resource
 
@@ -108,5 +109,6 @@ def dos_obj_resource(s3_store):
         enable_get_by_key=False,
         enable_default_search=True,
         sub_path="/dos/object/",
+        monty_encoded_response=True,
     )
     return resource


### PR DESCRIPTION
This PR enabled direct responses encoded with MontyEncoder for large object endpoints.