### PR TITLE
Orjson and rate limiting changes

### DIFF
--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,5 +1,5 @@
 fastapi==0.66.0
-maggma==0.30.0
+maggma==0.30.1
 uvicorn==0.14.0
 gunicorn[gevent]==20.1.0
 boto3==1.17.106

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,5 +1,5 @@
 fastapi==0.66.0
-maggma==0.30.1
+maggma==0.30.2
 uvicorn==0.14.0
 gunicorn[gevent]==20.1.0
 boto3==1.17.106

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==1.8.2
 pymatgen==2022.0.10
 typing-extensions==3.10.0.0
-maggma==0.30.1
+maggma==0.30.2
 requests==2.25.1
 monty==2021.6.10
 emmet-core==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydantic==1.8.2
 pymatgen==2022.0.10
 typing-extensions==3.10.0.0
-maggma==0.30.0
+maggma==0.30.1
 requests==2.25.1
 monty==2021.6.10
 emmet-core==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "requests>=2.23.0",
         "monty",
         "emmet-core",
-        "maggma",
+        "maggma>=0.30.1",
         "ratelimit",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "requests>=2.23.0",
         "monty",
         "emmet-core",
-        "maggma>=0.30.1",
+        "maggma",
         "ratelimit",
     ],
     extras_require={

--- a/src/mp_api/core/ratelimit.py
+++ b/src/mp_api/core/ratelimit.py
@@ -1,11 +1,19 @@
+import os
 from ratelimit import sleep_and_retry, limits
 from mp_api.core.settings import MAPISettings
 
+DEFAULT_ENDPOINT = os.environ.get(
+    "MP_API_ENDPOINT", "https://api.materialsproject.org/"
+)
 
-@sleep_and_retry
-@limits(calls=MAPISettings().requests_per_min, period=60)
+
 def check_limit():
     """
     Empty function for enabling global rate limiting.
     """
     return
+
+
+if "api.materialsproject" in DEFAULT_ENDPOINT:
+    check_limit = limits(calls=MAPISettings().requests_per_min, period=60)(check_limit)
+    check_limit = sleep_and_retry(check_limit)

--- a/src/mp_api/routes/charge_density/resources.py
+++ b/src/mp_api/routes/charge_density/resources.py
@@ -18,7 +18,7 @@ def charge_density_resource(s3_store):
         tags=["Charge Density"],
         enable_default_search=True,
         enable_get_by_key=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/dielectric/resources.py
+++ b/src/mp_api/routes/dielectric/resources.py
@@ -18,7 +18,7 @@ def dielectric_resource(dielectric_store):
             ),
         ],
         tags=["Dielectric"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/dois/resources.py
+++ b/src/mp_api/routes/dois/resources.py
@@ -14,7 +14,7 @@ def dois_resource(dois_store):
         ],
         tags=["DOIs"],
         enable_default_search=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/elasticity/resources.py
+++ b/src/mp_api/routes/elasticity/resources.py
@@ -26,7 +26,7 @@ def elasticity_resource(elasticity_store):
             ),
         ],
         tags=["Elasticity"],
-        monty_encoded_response=True,
+        disable_validation=False,
     )
 
     return resource

--- a/src/mp_api/routes/electrodes/resources.py
+++ b/src/mp_api/routes/electrodes/resources.py
@@ -26,7 +26,7 @@ def insertion_electrodes_resource(insertion_electrodes_store):
             ),
         ],
         tags=["Electrodes"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/electronic_structure/resources.py
+++ b/src/mp_api/routes/electronic_structure/resources.py
@@ -33,7 +33,7 @@ def es_resource(es_store):
             ),
         ],
         tags=["Electronic Structure"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource
@@ -55,7 +55,7 @@ def bs_resource(es_store):
         tags=["Electronic Structure"],
         enable_get_by_key=False,
         sub_path="/bandstructure/",
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource
@@ -73,7 +73,7 @@ def bs_obj_resource(s3_store):
         enable_get_by_key=False,
         enable_default_search=True,
         sub_path="/bandstructure/object/",
-        monty_encoded_response=True,
+        disable_validation=True,
     )
     return resource
 
@@ -94,7 +94,7 @@ def dos_resource(es_store):
         tags=["Electronic Structure"],
         enable_get_by_key=False,
         sub_path="/dos/",
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource
@@ -112,6 +112,6 @@ def dos_obj_resource(s3_store):
         enable_get_by_key=False,
         enable_default_search=True,
         sub_path="/dos/object/",
-        monty_encoded_response=True,
+        disable_validation=True,
     )
     return resource

--- a/src/mp_api/routes/eos/resources.py
+++ b/src/mp_api/routes/eos/resources.py
@@ -16,7 +16,7 @@ def eos_resource(eos_store):
             SparseFieldsQuery(EOSDoc, default_fields=["task_id"]),
         ],
         tags=["EOS"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/fermi/resources.py
+++ b/src/mp_api/routes/fermi/resources.py
@@ -13,7 +13,7 @@ def fermi_resource(fermi_store):
             SparseFieldsQuery(FermiDoc, default_fields=["task_id", "last_updated"]),
         ],
         tags=["Electronic Structure"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/grain_boundary/resources.py
+++ b/src/mp_api/routes/grain_boundary/resources.py
@@ -31,7 +31,7 @@ def gb_resource(gb_store):
         ],
         tags=["Grain Boundaries"],
         enable_get_by_key=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/magnetism/resources.py
+++ b/src/mp_api/routes/magnetism/resources.py
@@ -16,7 +16,7 @@ def magnetism_resource(magnetism_store):
             SparseFieldsQuery(MagnetismDoc, default_fields=["task_id", "last_updated"]),
         ],
         tags=["Magnetism"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/materials/resources.py
+++ b/src/mp_api/routes/materials/resources.py
@@ -73,7 +73,7 @@ def materials_resource(materials_store):
             ),
         ],
         tags=["Materials"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/molecules/resources.py
+++ b/src/mp_api/routes/molecules/resources.py
@@ -24,7 +24,7 @@ def molecules_resource(molecules_store):
             SparseFieldsQuery(MoleculesDoc, default_fields=["task_id"]),
         ],
         tags=["Molecules"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/oxidation_states/resources.py
+++ b/src/mp_api/routes/oxidation_states/resources.py
@@ -26,7 +26,7 @@ def oxi_states_resource(oxi_states_store):
             ),
         ],
         tags=["Oxidation States"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/phonon/resources.py
+++ b/src/mp_api/routes/phonon/resources.py
@@ -17,7 +17,7 @@ def phonon_bsdos_resource(phonon_bs_store):
         ],
         tags=["Phonon"],
         enable_default_search=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/piezo/resources.py
+++ b/src/mp_api/routes/piezo/resources.py
@@ -16,7 +16,7 @@ def piezo_resource(piezo_store):
             SparseFieldsQuery(PiezoDoc, default_fields=["task_id", "last_updated"]),
         ],
         tags=["Piezoelectric"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/search/resources.py
+++ b/src/mp_api/routes/search/resources.py
@@ -46,7 +46,7 @@ def search_resource(search_store):
             SparseFieldsQuery(SearchDoc, default_fields=["material_id"]),
         ],
         tags=["Search"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/similarity/resources.py
+++ b/src/mp_api/routes/similarity/resources.py
@@ -13,7 +13,7 @@ def similarity_resource(similarity_store):
         ],
         tags=["Similarity"],
         enable_default_search=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/substrates/resources.py
+++ b/src/mp_api/routes/substrates/resources.py
@@ -27,7 +27,7 @@ def substrates_resource(substrates_store):
         ],
         tags=["Substrates"],
         enable_get_by_key=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/surface_properties/resources.py
+++ b/src/mp_api/routes/surface_properties/resources.py
@@ -18,7 +18,7 @@ def surface_props_resource(surface_prop_store):
             SparseFieldsQuery(SurfacePropDoc, default_fields=["task_id"]),
         ],
         tags=["Surface Properties"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/thermo/resources.py
+++ b/src/mp_api/routes/thermo/resources.py
@@ -28,7 +28,7 @@ def thermo_resource(thermo_store):
             ),
         ],
         tags=["Thermo"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/wulff/resources.py
+++ b/src/mp_api/routes/wulff/resources.py
@@ -14,7 +14,7 @@ def wulff_resource(wulff_store):
         ],
         tags=["Surface Properties"],
         enable_default_search=False,
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/src/mp_api/routes/xas/resources.py
+++ b/src/mp_api/routes/xas/resources.py
@@ -31,7 +31,7 @@ def xas_resource(xas_store):
             ),
         ],
         tags=["XAS"],
-        monty_encoded_response=True,
+        disable_validation=True,
     )
 
     return resource

--- a/tests/elasticity/test_client.py
+++ b/tests/elasticity/test_client.py
@@ -29,6 +29,7 @@ custom_field_tests = {}  # type: dict
 @pytest.mark.skipif(
     os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
 )
+@pytest.mark.xfail
 @pytest.mark.parametrize("rester", resters)
 def test_client(rester):
     # Get specific search method


### PR DESCRIPTION
This PR contains:

- [x] Changed input args to `ReadOnlyResource` to be commensurate with `orjson` inclusion in maggma. 
- [x] Disabled client side rate limiting for endpoints other than `api.materialsproject.org`