### PR TITLE
Task_id to material_id in xas tests

### DIFF
--- a/tests/xas/test_query_operators.py
+++ b/tests/xas/test_query_operators.py
@@ -34,14 +34,14 @@ def test_xas_operator():
 def test_xas_task_id_operator():
     op = XASTaskIDQuery()
 
-    assert op.query(task_ids="mp-149, mp-13") == {
-        "criteria": {"task_id": {"$in": ["mp-149", "mp-13"]}}
+    assert op.query(material_ids="mp-149, mp-13") == {
+        "criteria": {"material_id": {"$in": ["mp-149", "mp-13"]}}
     }
 
     with ScratchDir("."):
         dumpfn(op, "temp.json")
         new_op = loadfn("temp.json")
 
-        assert new_op.query(task_ids="mp-149, mp-13") == {
-            "criteria": {"task_id": {"$in": ["mp-149", "mp-13"]}}
+        assert new_op.query(material_ids="mp-149, mp-13") == {
+            "criteria": {"material_id": {"$in": ["mp-149", "mp-13"]}}
         }


### PR DESCRIPTION
This fixes xas tests to accommodate change in query operators from `task_id` to `material_id`. 