### PR TITLE
Initial blue/green changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ default_settings = MAPISettings()
 
 db_uri = os.environ.get("MPCONTRIBS_MONGO_HOST", None)
 db_version = os.environ.get("DB_VERSION", default_settings.DB_VERSION)
+db_suffix = os.environ.get("DB_NAME_SUFFIX", default_settings.DB_NAME_SUFFIX)
 debug = os.environ.get("API_DEBUG", default_settings.DEBUG)
 
 materials_store_json = os.environ.get("MATERIALS_STORE", "materials_store.json")
@@ -72,7 +73,7 @@ if db_uri:
 
     materials_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name=f"materials.core_{db_version}",
     )
@@ -93,21 +94,21 @@ if db_uri:
 
     thermo_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name=f"thermo_{db_version}",
     )
 
     dielectric_piezo_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="task_id",
         collection_name="dielectric",
     )
 
     magnetism_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="task_id",
         collection_name="magnetism",
     )
@@ -184,7 +185,7 @@ if db_uri:
 
     robo_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name="robocrys",
     )
@@ -198,7 +199,7 @@ if db_uri:
 
     insertion_electrodes_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="battery_id",
         collection_name="insertion_electrodes",
     )
@@ -212,28 +213,28 @@ if db_uri:
 
     oxi_states_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name="oxi_states",
     )
 
     provenance_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name="provenance",
     )
 
     summary_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name="summary",
     )
 
     es_store = MongoURIStore(
         uri=f"mongodb+srv://{db_uri}",
-        database="mp_core",
+        database=f"mp_core_{db_suffix}",
         key="material_id",
         collection_name="electronic_structure",
     )

--- a/app.py
+++ b/app.py
@@ -9,8 +9,8 @@ resources = {}
 default_settings = MAPISettings()
 
 db_uri = os.environ.get("MPCONTRIBS_MONGO_HOST", None)
-db_version = os.environ.get("DB_VERSION", default_settings.db_version)
-debug = os.environ.get("API_DEBUG", default_settings.debug)
+db_version = os.environ.get("DB_VERSION", default_settings.DB_VERSION)
+debug = os.environ.get("API_DEBUG", default_settings.DEBUG)
 
 materials_store_json = os.environ.get("MATERIALS_STORE", "materials_store.json")
 formula_autocomplete_store_json = os.environ.get(

--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ default_settings = MAPISettings()
 
 db_uri = os.environ.get("MPCONTRIBS_MONGO_HOST", None)
 db_version = os.environ.get("DB_VERSION", default_settings.DB_VERSION)
-db_suffix = os.environ.get("DB_NAME_SUFFIX", default_settings.DB_NAME_SUFFIX)
+db_suffix = os.environ.get("DB_NAME_SUFFIX", db_version)
 debug = os.environ.get("API_DEBUG", default_settings.DEBUG)
 
 materials_store_json = os.environ.get("MATERIALS_STORE", "materials_store.json")

--- a/src/mp_api/__init__.py
+++ b/src/mp_api/__init__.py
@@ -21,17 +21,17 @@ from pathlib import Path
 settings = MAPISettings()
 
 try:  # pragma: no cover
-    if Path(settings.app_path).exists():
-        mapi = loadfn(settings.app_path)
+    if Path(settings.APP_PATH).exists():
+        mapi = loadfn(settings.APP_PATH)
         app = mapi.app
     else:
         app = None
-        if settings.debug:
-            print(f"Failed loading App at {settings.app_path}")
+        if settings.DEBUG:
+            print(f"Failed loading App at {settings.APP_PATH}")
 
 except Exception as e:  # pragma: no cover
     # Something went wrong with loading default app
-    if settings.debug:
+    if settings.DEBUG:
         print("Failed loading App")
         print(e)
         app = None

--- a/src/mp_api/core/api.py
+++ b/src/mp_api/core/api.py
@@ -20,7 +20,7 @@ class MAPI(API):
         debug=False,
         heartbeat_meta={
             "pymatgen": pmg_version,
-            "db_version": MAPISettings().db_version,
+            "db_version": MAPISettings().DB_VERSION,
         },
         description=None,
         tags_meta=None,

--- a/src/mp_api/core/ratelimit.py
+++ b/src/mp_api/core/ratelimit.py
@@ -15,5 +15,5 @@ def check_limit():
 
 
 if "api.materialsproject" in DEFAULT_ENDPOINT:
-    check_limit = limits(calls=MAPISettings().requests_per_min, period=60)(check_limit)
+    check_limit = limits(calls=MAPISettings().REQUESTS_PER_MIN, period=60)(check_limit)
     check_limit = sleep_and_retry(check_limit)

--- a/src/mp_api/core/settings.py
+++ b/src/mp_api/core/settings.py
@@ -22,7 +22,7 @@ class MAPISettings(BaseSettings):
 
     DB_VERSION: str = Field("2021_prerelease", description="Database version")
 
-    DB_NAME_SUFFIX: str = Field(..., description="Database name suffix")
+    DB_NAME_SUFFIX: str = Field(None, description="Database name suffix")
 
     REQUESTS_PER_MIN: int = Field(
         100, description="Number of requests per minute to for rate limit."

--- a/src/mp_api/core/settings.py
+++ b/src/mp_api/core/settings.py
@@ -9,22 +9,24 @@ class MAPISettings(BaseSettings):
     python module
     """
 
-    app_path: str = Field(
+    APP_PATH: str = Field(
         "~/mapi.json", description="Path for the default MAPI JSON definition"
     )
 
-    debug: bool = Field(False, description="Turns on debug mode for MAPI")
+    DEBUG: bool = Field(False, description="Turns on debug mode for MAPI")
 
-    test_files: str = Field(
+    TEST_FILES: str = Field(
         os.path.join(os.path.dirname(os.path.abspath(root_dir)), "../../test_files"),
         description="Directory with test files",
     )
 
-    db_version: str = Field("2021_prerelease", description="Database version")
+    DB_VERSION: str = Field("2021_prerelease", description="Database version")
 
-    requests_per_min: int = Field(
+    DB_NAME_SUFFIX: str = Field(..., description="Database name suffix")
+
+    REQUESTS_PER_MIN: int = Field(
         100, description="Number of requests per minute to for rate limit."
     )
 
     class Config:
-        env_prefix = "mapi_"
+        env_prefix = "MAPI_"

--- a/src/mp_api/routes/materials/resources.py
+++ b/src/mp_api/routes/materials/resources.py
@@ -13,8 +13,6 @@ from maggma.api.query_operator import (
     NumericQuery,
 )
 
-from mp_api.core.settings import MAPISettings
-
 from mp_api.routes.materials.query_operators import (
     ElementsQuery,
     FormulaQuery,
@@ -24,8 +22,6 @@ from mp_api.routes.materials.query_operators import (
     FindStructureQuery,
     FormulaAutoCompleteQuery,
 )
-
-from pymongo import MongoClient  # type: ignore
 
 
 def find_structure_resource(materials_store):

--- a/tests/materials/test_query_operators.py
+++ b/tests/materials/test_query_operators.py
@@ -129,7 +129,7 @@ def test_find_structure_query():
     op = FindStructureQuery()
 
     structure = Structure.from_file(
-        os.path.join(MAPISettings().test_files, "Si_mp_149.cif")
+        os.path.join(MAPISettings().TEST_FILES, "Si_mp_149.cif")
     )
     assert op.query(
         structure=structure.as_dict(), ltol=0.2, stol=0.3, angle_tol=5, limit=1

--- a/tests/mpcomplete/test_query_operators.py
+++ b/tests/mpcomplete/test_query_operators.py
@@ -15,7 +15,7 @@ def test_mpcomplete_post_query():
     op = MPCompletePostQuery()
 
     structure = Structure.from_file(
-        os.path.join(MAPISettings().test_files, "Si_mp_149.cif")
+        os.path.join(MAPISettings().TEST_FILES, "Si_mp_149.cif")
     )
 
     assert op.query(

--- a/tests/synthesis/test_adaptor.py
+++ b/tests/synthesis/test_adaptor.py
@@ -8,14 +8,16 @@ from mp_api.routes.synthesis.data_adaptor import string2comp, convert_recipe
 
 
 def test_string2comp():
-    assert string2comp('BaTiO3') == Composition('BaTiO3')
-    assert string2comp('LiOH·H2O') == Composition('LiOH')
-    assert string2comp('TiO2·BaCO3') == Composition('TiO2')
+    assert string2comp("BaTiO3") == Composition("BaTiO3")
+    assert string2comp("LiOH·H2O") == Composition("LiOH")
+    assert string2comp("TiO2·BaCO3") == Composition("TiO2")
 
 
 def test_convert_recipe():
-    with open(os.path.join(MAPISettings().test_files, "synth_doc_adaptor.json")) as file:
+    with open(
+        os.path.join(MAPISettings().TEST_FILES, "synth_doc_adaptor.json")
+    ) as file:
         synth_doc = load(file)
 
-    converted = convert_recipe(synth_doc['src'])
-    assert converted == synth_doc['product']
+    converted = convert_recipe(synth_doc["src"])
+    assert converted == synth_doc["product"]

--- a/tests/synthesis/test_adaptor_synpro.py
+++ b/tests/synthesis/test_adaptor_synpro.py
@@ -4,95 +4,101 @@ from json import load
 from pymatgen.core import Composition
 
 from mp_api import MAPISettings
-from mp_api.routes.synthesis.data_adaptor_synpro import convert_value, convert_conditions, convert_one, \
-    get_material_formula
+from mp_api.routes.synthesis.data_adaptor_synpro import (
+    convert_value,
+    convert_conditions,
+    convert_one,
+    get_material_formula,
+)
 
 
 def test_convert_value():
-    src = {
-        "min": None,
-        "max": 350.0,
-        "values": [350.0],
-        "tok_ids": [19],
-        "units": "°C"
-    }
+    src = {"min": None, "max": 350.0, "values": [350.0], "tok_ids": [19], "units": "°C"}
     product = {
-        'min_value': None,
-        'max_value': 350.0,
-        'values': [350.0],
-        'units': "°C",
+        "min_value": None,
+        "max_value": 350.0,
+        "values": [350.0],
+        "units": "°C",
     }
     assert convert_value(src) == product
 
 
 def test_conditions():
     src = {
-        "temperature": [{"min": None, "max": 350.0, "values": [350.0], "tok_ids": [19], "units": "°C"}],
-        "time": [{"max": 3.0, "min": 3.0, "values": [3.0], "tok_ids": [23], "units": "h"}],
-        "environment": ["air", "O2"]
+        "temperature": [
+            {
+                "min": None,
+                "max": 350.0,
+                "values": [350.0],
+                "tok_ids": [19],
+                "units": "°C",
+            }
+        ],
+        "time": [
+            {"max": 3.0, "min": 3.0, "values": [3.0], "tok_ids": [23], "units": "h"}
+        ],
+        "environment": ["air", "O2"],
     }
     product = {
-        'heating_temperature': [{'min_value': None, 'max_value': 350.0, 'values': [350.0], 'units': "°C", }],
-        'heating_time': [{'min_value': 3.0, 'max_value': 3.0, 'values': [3.0], 'units': 'h'}],
-        'heating_atmosphere': ["air", "O2"],
-        'mixing_device': None,
-        'mixing_media': None
+        "heating_temperature": [
+            {"min_value": None, "max_value": 350.0, "values": [350.0], "units": "°C",}
+        ],
+        "heating_time": [
+            {"min_value": 3.0, "max_value": 3.0, "values": [3.0], "units": "h"}
+        ],
+        "heating_atmosphere": ["air", "O2"],
+        "mixing_device": None,
+        "mixing_media": None,
     }
-    assert convert_conditions(src, 'HeatingOperation') == product
+    assert convert_conditions(src, "HeatingOperation") == product
 
     product = {
-        'heating_temperature': [{'min_value': None, 'max_value': 350.0, 'values': [350.0], 'units': "°C", }],
-        'heating_time': [{'min_value': 3.0, 'max_value': 3.0, 'values': [3.0], 'units': 'h'}],
-        'heating_atmosphere': [],
-        'mixing_device': 'O2',
-        'mixing_media': 'air'
+        "heating_temperature": [
+            {"min_value": None, "max_value": 350.0, "values": [350.0], "units": "°C",}
+        ],
+        "heating_time": [
+            {"min_value": 3.0, "max_value": 3.0, "values": [3.0], "units": "h"}
+        ],
+        "heating_atmosphere": [],
+        "mixing_device": "O2",
+        "mixing_media": "air",
     }
-    assert convert_conditions(src, 'MixingOperation') == product
+    assert convert_conditions(src, "MixingOperation") == product
 
 
 def test_get_material_formula():
-    assert get_material_formula({
-        "material_formula": "NH4H2PO4",
-        "composition": [
-            {
-                "formula": "NH4H2PO4",
-                "amount": "1",
-                "elements": {
-                    "N": "1",
-                    "H": "6",
-                    "P": "1",
-                    "O": "4"
-                },
-            }
-        ],
-    }) == Composition('NH4H2PO4')
+    assert get_material_formula(
+        {
+            "material_formula": "NH4H2PO4",
+            "composition": [
+                {
+                    "formula": "NH4H2PO4",
+                    "amount": "1",
+                    "elements": {"N": "1", "H": "6", "P": "1", "O": "4"},
+                }
+            ],
+        }
+    ) == Composition("NH4H2PO4")
 
-    assert get_material_formula({
-        "material_formula": "TiO2-2BaCO3",
-        "composition": [
-            {
-                "formula": "TiO2",
-                "amount": "1",
-                "elements": {
-                    "Ti": "1",
-                    "O": "2"
+    assert get_material_formula(
+        {
+            "material_formula": "TiO2-2BaCO3",
+            "composition": [
+                {"formula": "TiO2", "amount": "1", "elements": {"Ti": "1", "O": "2"},},
+                {
+                    "formula": "BaCO3",
+                    "amount": "2",
+                    "elements": {"Ba": "1", "C": "1", "O": "3"},
                 },
-            },
-            {
-                "formula": "BaCO3",
-                "amount": "2",
-                "elements": {
-                    "Ba": "1",
-                    "C": "1",
-                    "O": "3"
-                },
-            }
-        ],
-    }) == Composition('TiBa2C2O8')
+            ],
+        }
+    ) == Composition("TiBa2C2O8")
 
 
 def test_convert_one():
-    with open(os.path.join(MAPISettings().test_files, "synth_doc_adaptor_synpro.json")) as file:
+    with open(
+        os.path.join(MAPISettings().TEST_FILES, "synth_doc_adaptor_synpro.json")
+    ) as file:
         synth_doc = load(file)
 
-    assert convert_one(synth_doc['src']) == synth_doc['product']
+    assert convert_one(synth_doc["src"]) == synth_doc["product"]

--- a/tests/synthesis/test_utils.py
+++ b/tests/synthesis/test_utils.py
@@ -19,7 +19,7 @@ def test_make_ellipsis():
 
 
 def test_mask_paragraphs():
-    with open(os.path.join(MAPISettings().test_files, "synth_doc.json")) as file:
+    with open(os.path.join(MAPISettings().TEST_FILES, "synth_doc.json")) as file:
         synth_doc = load(file)
 
     doc = SynthesisSearchResultModel(**synth_doc)
@@ -29,7 +29,7 @@ def test_mask_paragraphs():
 
 
 def test_mask_highlights():
-    with open(os.path.join(MAPISettings().test_files, "synth_doc.json")) as file:
+    with open(os.path.join(MAPISettings().TEST_FILES, "synth_doc.json")) as file:
         synth_doc = load(file)
 
     doc = SynthesisSearchResultModel(**synth_doc)

--- a/tests/tasks/test_query_operators.py
+++ b/tests/tasks/test_query_operators.py
@@ -42,7 +42,7 @@ def test_trajectory_query():
             "criteria": {"task_id": {"$in": ["mp-149", "mp-13"]}}
         }
 
-    with open(os.path.join(MAPISettings().test_files, "tasks_Li_Fe_V.json")) as file:
+    with open(os.path.join(MAPISettings().TEST_FILES, "tasks_Li_Fe_V.json")) as file:
         tasks = load(file)
     docs = op.post_process(tasks)
     assert docs[0]["trajectories"][0]["@class"] == "Trajectory"

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -6,9 +6,15 @@ from mp_api.routes.tasks.utils import calcs_reversed_to_trajectory
 
 
 def test_calcs_reversed_to_trajectory():
-    with open(os.path.join(MAPISettings().test_files, "calcs_reversed_mp_1031016.json")) as file:
+    with open(
+        os.path.join(MAPISettings().TEST_FILES, "calcs_reversed_mp_1031016.json")
+    ) as file:
         calcs_reversed = load(file)
         trajectories = calcs_reversed_to_trajectory(calcs_reversed)
 
     assert len(trajectories) == 1
-    assert trajectories[0]["lattice"] == [[9.054455, 0.0, 0.0], [0.0, 4.500098, 0.0], [0.0, 0.0, 4.500098]]
+    assert trajectories[0]["lattice"] == [
+        [9.054455, 0.0, 0.0],
+        [0.0, 4.500098, 0.0],
+        [0.0, 0.0, 4.500098],
+    ]

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -50,7 +50,7 @@ class TestMPRester:
 
     def test_get_database_version(self, mpr):
         db_version = mpr.get_database_version()
-        assert db_version == MAPISettings().db_version
+        assert db_version == MAPISettings().DB_VERSION
 
     def test_get_materials_id_from_task_id(self, mpr):
         assert mpr.get_materials_id_from_task_id("mp-540081") == "mp-19017"
@@ -79,7 +79,7 @@ class TestMPRester:
         assert len(structs) > 0
 
     def test_find_structure(self, mpr):
-        path = os.path.join(MAPISettings().test_files, "Si_mp_149.cif")
+        path = os.path.join(MAPISettings().TEST_FILES, "Si_mp_149.cif")
         with open(path) as file:
             data = mpr.find_structure(path)
             assert len(data) > 0


### PR DESCRIPTION
This PR allows the API to accommodate new blue/green databases for certain collections through a new `MAPI_DB_NAME_SUFFIX` environment variable. 

Additionally, all necessary environment variables for the API except for the main database URI should now be prefixed with `MAPI_`. This includes `MAPI_DB_VERSION` and `MAPI_API_DEBUG`.