### PR TITLE
Convert to using HasProps enum for summary client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ typing-extensions==4.0.0
 maggma==0.32.2
 requests==2.26.0
 monty==2021.8.17
-emmet-core==0.17.0
+emmet-core==0.18.0
 ratelimit==2.2.1
 mpcontribs-client>=3.14.3

--- a/src/mp_api/client.py
+++ b/src/mp_api/client.py
@@ -9,6 +9,7 @@ from emmet.core.mpid import MPID
 from emmet.core.settings import EmmetSettings
 from emmet.core.symmetry import CrystalSystem
 from emmet.core.vasp.calc_types import CalcType
+from emmet.core.summary import HasProps
 from mpcontribs.client import Client
 from pymatgen.analysis.magnetism import Ordering
 from pymatgen.analysis.phase_diagram import PhaseDiagram
@@ -845,7 +846,7 @@ class MPRester:
         surface_energy_anisotropy: Optional[Tuple[float, float]] = None,
         shape_factor: Optional[Tuple[float, float]] = None,
         has_reconstructed: Optional[bool] = None,
-        has_props: Optional[List[str]] = None,
+        has_props: Optional[List[HasProps]] = None,
         theoretical: Optional[bool] = None,
         sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
@@ -918,7 +919,7 @@ class MPRester:
                 consider.
             shape_factor (Tuple[float,float]): Minimum and maximum shape factor values to consider.
             has_reconstructed (bool): Whether the entry has any reconstructed surfaces.
-            has_props: (List[str]): The calculated properties available for the material.
+            has_props: (List[HasProps]): The calculated properties available for the material.
             theoretical: (bool): Whether the material is theoretical.
             sort_fields (List[str]): Fields used to sort results. Prefixing with '-' will sort in descending order.
             num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.

--- a/src/mp_api/routes/summary/client.py
+++ b/src/mp_api/routes/summary/client.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import List, Optional, Tuple
 
 from emmet.core.mpid import MPID
-from emmet.core.summary import SummaryDoc
+from emmet.core.summary import SummaryDoc, HasProps
 from emmet.core.symmetry import CrystalSystem
 from mp_api.core.client import BaseRester
 from pymatgen.analysis.magnetism import Ordering
@@ -63,7 +63,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
         surface_energy_anisotropy: Optional[Tuple[float, float]] = None,
         shape_factor: Optional[Tuple[float, float]] = None,
         has_reconstructed: Optional[bool] = None,
-        has_props: Optional[List[str]] = None,
+        has_props: Optional[List[HasProps]] = None,
         theoretical: Optional[bool] = None,
         sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
@@ -136,7 +136,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
                 consider.
             shape_factor (Tuple[float,float]): Minimum and maximum shape factor values to consider.
             has_reconstructed (bool): Whether the entry has any reconstructed surfaces.
-            has_props: (List[str]): The calculated properties available for the material.
+            has_props: (List[HasProps]): The calculated properties available for the material.
             theoretical: (bool): Whether the material is theoretical.
             sort_fields (List[str]): Fields used to sort results. Prefixing with '-' will sort in descending order.
             num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.
@@ -234,7 +234,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
             query_params.update({"has_reconstructed": has_reconstructed})
 
         if has_props:
-            query_params.update({"has_props": ",".join(has_props)})
+            query_params.update({"has_props": ",".join([i.value for i in has_props])})
 
         if theoretical is not None:
             query_params.update({"theoretical": theoretical})

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -5,6 +5,7 @@ import typing
 import pytest
 from emmet.core.symmetry import CrystalSystem
 from emmet.core.vasp.calc_types import CalcType
+from emmet.core.summary import HasProps
 from mp_api.core.settings import MAPISettings
 from mp_api.matproj import MPRester
 from mp_api.routes.tasks.models import TaskDoc
@@ -263,7 +264,7 @@ class TestMPRester:
             "crystal_system": CrystalSystem.cubic,
             "spacegroup_number": 38,
             "spacegroup_symbol": "Amm2",
-            "has_props": ["dielectric"],
+            "has_props": [HasProps.dielectric],
             "theoretical": True,
             "has_reconstructed": False,
             "magnetic_ordering": Ordering.FM,


### PR DESCRIPTION
This PR accommodates data changes involving the use of a new `HasProps` enum to define the `has_props` fields.