### PR TITLE
Update prefixed query params

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Test with pytest
         env:
           MP_API_KEY: ${{ secrets.MP_API_KEY }}
+          MP_API_ENDPOINT: https://api-preview.materialsproject.org/
         run: |
           pip install -e .
           pytest --cov=mp_api --cov-report=xml

--- a/src/mp_api/core/settings.py
+++ b/src/mp_api/core/settings.py
@@ -33,8 +33,8 @@ class MAPIClientSettings(BaseSettings):
             "condition_mixing_media",
             "condition_heating_atmosphere",
             "operations",
-            "sort_fields",
-            "fields",
+            "_sort_fields",
+            "_fields",
         ],
         description="List API query parameters that do not support parallel requests.",
     )

--- a/src/mp_api/routes/bonds.py
+++ b/src/mp_api/routes/bonds.py
@@ -84,7 +84,7 @@ class BondsRester(BaseRester[BondingDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/dielectric.py
+++ b/src/mp_api/routes/dielectric.py
@@ -63,7 +63,7 @@ class DielectricRester(BaseRester[DielectricDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/elasticity.py
+++ b/src/mp_api/routes/elasticity.py
@@ -93,7 +93,7 @@ class ElasticityRester(BaseRester[ElasticityDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/electrodes.py
+++ b/src/mp_api/routes/electrodes.py
@@ -87,7 +87,7 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         for param, value in locals().items():

--- a/src/mp_api/routes/electronic_structure.py
+++ b/src/mp_api/routes/electronic_structure.py
@@ -304,6 +304,7 @@ class DosRester(BaseRester):
         band_gap: Optional[Tuple[float, float]] = None,
         efermi: Optional[Tuple[float, float]] = None,
         magnetic_ordering: Optional[Ordering] = None,
+        sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
         chunk_size: int = 1000,
         all_fields: bool = True,
@@ -320,6 +321,7 @@ class DosRester(BaseRester):
             band_gap (Tuple[float,float]): Minimum and maximum band gap in eV to consider.
             efermi (Tuple[float,float]): Minimum and maximum fermi energy in eV to consider.
             magnetic_ordering (Ordering): Magnetic ordering of the material.
+            sort_fields (List[str]): Fields used to sort results. Prefix with '-' to sort in descending order.
             num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.
             chunk_size (int): Number of data entries per chunk.
             all_fields (bool): Whether to return all fields in the document. Defaults to True.
@@ -351,6 +353,11 @@ class DosRester(BaseRester):
 
         if magnetic_ordering:
             query_params.update({"magnetic_ordering": magnetic_ordering.value})
+
+        if sort_fields:
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
         query_params = {
             entry: query_params[entry]

--- a/src/mp_api/routes/electronic_structure.py
+++ b/src/mp_api/routes/electronic_structure.py
@@ -97,7 +97,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {
@@ -178,7 +178,7 @@ class BandStructureRester(BaseRester):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {
@@ -207,7 +207,7 @@ class BandStructureRester(BaseRester):
         """
 
         result = self._query_resource(
-            criteria={"task_id": task_id, "all_fields": True},
+            criteria={"task_id": task_id, "_all_fields": True},
             suburl="object",
             use_document_model=False,
             num_chunks=1,
@@ -378,7 +378,7 @@ class DosRester(BaseRester):
         """
 
         result = self._query_resource(
-            criteria={"task_id": task_id, "all_fields": True},
+            criteria={"task_id": task_id, "_all_fields": True},
             suburl="object",
             use_document_model=False,
             num_chunks=1,

--- a/src/mp_api/routes/eos.py
+++ b/src/mp_api/routes/eos.py
@@ -50,7 +50,7 @@ class EOSRester(BaseRester[EOSDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/grain_boundary.py
+++ b/src/mp_api/routes/grain_boundary.py
@@ -100,7 +100,7 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/magnetism.py
+++ b/src/mp_api/routes/magnetism.py
@@ -108,7 +108,7 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/materials.py
+++ b/src/mp_api/routes/materials.py
@@ -128,7 +128,7 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {
@@ -175,7 +175,7 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
             MPRestError
         """
 
-        params = {"ltol": ltol, "stol": stol, "angle_tol": angle_tol, "limit": 1}
+        params = {"ltol": ltol, "stol": stol, "angle_tol": angle_tol, "_limit": 1}
 
         if isinstance(filename_or_structure, str):
             s = Structure.from_file(filename_or_structure)

--- a/src/mp_api/routes/molecules.py
+++ b/src/mp_api/routes/molecules.py
@@ -77,7 +77,7 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/piezo.py
+++ b/src/mp_api/routes/piezo.py
@@ -49,7 +49,7 @@ class PiezoRester(BaseRester[PiezoelectricDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/robocrys.py
+++ b/src/mp_api/routes/robocrys.py
@@ -31,7 +31,7 @@ class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
         keyword_string = ",".join(keywords)
 
         robocrys_docs = self._query_resource(
-            criteria={"keywords": keyword_string, "limit": chunk_size},
+            criteria={"keywords": keyword_string, "_limit": chunk_size},
             suburl="text_search",
             use_document_model=True,
             chunk_size=100,

--- a/src/mp_api/routes/substrates.py
+++ b/src/mp_api/routes/substrates.py
@@ -83,7 +83,7 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/summary.py
+++ b/src/mp_api/routes/summary.py
@@ -254,7 +254,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/surface_properties.py
+++ b/src/mp_api/routes/surface_properties.py
@@ -85,7 +85,7 @@ class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         query_params = {

--- a/src/mp_api/routes/synthesis.py
+++ b/src/mp_api/routes/synthesis.py
@@ -72,7 +72,7 @@ class SynthesisRester(BaseRester[SynthesisSearchResultModel]):
                 "condition_heating_atmosphere": condition_heating_atmosphere,
                 "condition_mixing_device": condition_mixing_device,
                 "condition_mixing_media": condition_mixing_media,
-                "limit": chunk_size,
+                "_limit": chunk_size,
             },
             chunk_size=chunk_size,
             num_chunks=num_chunks,

--- a/src/mp_api/routes/thermo.py
+++ b/src/mp_api/routes/thermo.py
@@ -83,7 +83,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         name_dict = {

--- a/src/mp_api/routes/xas.py
+++ b/src/mp_api/routes/xas.py
@@ -71,7 +71,7 @@ class XASRester(BaseRester[XASDoc]):
 
         if sort_fields:
             query_params.update(
-                {"sort_fields": ",".join([s.strip() for s in sort_fields])}
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
             )
 
         return super().search(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,7 +48,7 @@ def test_generic_get_methods(rester):
     if name not in ignore_generic:
         if name not in key_only_resters:
             doc = rester._query_resource_data(
-                {"limit": 1}, fields=[rester.primary_key]
+                {"_limit": 1}, fields=[rester.primary_key]
             )[0]
             assert isinstance(doc, rester.document_model)
 

--- a/tests/test_core_client.py
+++ b/tests/test_core_client.py
@@ -41,7 +41,7 @@ def test_pagination(mpr):
 )
 def test_count(mpr):
     count = mpr.materials.count(
-        dict(task_ids="mp-149", all_fields=False, fields="material_id")
+        dict(task_ids="mp-149", _all_fields=False, _fields="material_id")
     )
     assert count == 1
 


### PR DESCRIPTION
This PR updates pagination, sorting, and fields projection query parameters which are changed in https://github.com/materialsproject/maggma/pull/620

It also renamed `chunk` and `num_chunks` to `page` and `per_page` to be commensurate with maggma pagination changes.