### PR TITLE
Add minimal API key validation

### DIFF
--- a/src/mp_api/client.py
+++ b/src/mp_api/client.py
@@ -118,6 +118,11 @@ class MPRester:
                 and will not give auto-complete for available fields.
         """
 
+        if api_key and len(api_key) == 16:
+            raise ValueError("Please use a new API key from https://next-gen.materialsproject.org/api "
+                             "Keys for the new API are 32 characters, whereas keys for the legacy "
+                             "API are 16 characters.")
+
         self.api_key = api_key
         self.endpoint = endpoint
         self.session = BaseRester._create_session(


### PR DESCRIPTION
Checks that the API key is not 16 characters, meaning it would be a legacy API key.