### PR TITLE
Use boto3 instead of direct get requests in client for charge density data

### DIFF
--- a/src/mp_api/routes/charge_density.py
+++ b/src/mp_api/routes/charge_density.py
@@ -1,18 +1,22 @@
+import zlib
+from os import environ
 from pathlib import Path
+from typing import Dict, List, Optional, Union
 
-from typing import Union, Optional, List, Dict
+import boto3
+import msgpack
+from botocore import UNSIGNED
+from botocore.client import Config
+from botocore.exceptions import ConnectionError
 
 try:
     from typing import Literal  # type: ignore
 except ImportError:
     from typing_extensions import Literal  # type: ignore
 
-from warnings import warn
-
-from monty.serialization import dumpfn
-
-from mp_api.core.client import BaseRester
 from emmet.core.charge_density import ChgcarDataDoc
+from monty.serialization import MontyDecoder, dumpfn
+from mp_api.core.client import BaseRester
 
 
 class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
@@ -20,6 +24,7 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
     suffix = "charge_density"
     primary_key = "task_id"
     document_model = ChgcarDataDoc  # type: ignore
+    boto_resource = None
 
     def download_for_task_ids(
         self,
@@ -69,3 +74,72 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
             fields=["last_updated", "task_id", "fs_id"],
             **kwargs,
         )
+
+    def get_charge_density_from_file_id(self, fs_id: str):
+        url_doc = self.get_data_by_id(fs_id)
+
+        if url_doc:
+
+            # The check below is performed to see if the client is being
+            # used by our internal AWS deployment. If it is, we pull charge
+            # density data from a private S3 bucket. Else, we pull data
+            # from public MinIO buckets.
+            if environ.get("AWS_EXECUTION_ENV", None) == "AWS_ECS_FARGATE":
+
+                if self.boto_resource is None:
+                    self.boto_resource = self._get_s3_resource(use_minio=False)
+
+            else:
+                try:
+                    if self.boto_resource is None:
+                        self.boto_resource = self._get_s3_resource()
+
+                    bucket, obj_prefix = self._extract_s3_url_info(url_doc)
+
+                except ConnectionError:
+                    self.boto_resource = self._get_s3_resource(use_minio=False)
+
+                    bucket, obj_prefix = self._extract_s3_url_info(
+                        url_doc, use_minio=False
+                    )
+
+            r = self.boto_resource.Object(  # type: ignore
+                bucket, "{}/{}".format(obj_prefix, url_doc.fs_id)
+            ).get()["Body"]
+
+            packed_bytes = r.read()
+
+            packed_bytes = zlib.decompress(packed_bytes)
+            json_data = msgpack.unpackb(packed_bytes, raw=False)
+            chgcar = MontyDecoder().process_decoded(json_data["data"])
+
+            return chgcar
+
+        else:
+            return None
+
+    def _extract_s3_url_info(self, url_doc, use_minio: bool = True):
+
+        if use_minio:
+            url_list = url_doc.url.split("/")
+            bucket = url_list[3]
+            obj_prefix = url_list[4]
+        else:
+            url_list = url_doc.s3_url_prefix.split("/")
+            bucket = url_list[2].split(".")[0]
+            obj_prefix = url_list[3]
+
+        return (bucket, obj_prefix)
+
+    def _get_s3_resource(self, use_minio: bool = True):
+
+        if use_minio:
+            resource = boto3.resource(
+                "s3",
+                endpoint_url="https://minio.materialsproject.org",
+                config=Config(signature_version=UNSIGNED),
+            )
+        else:
+            resource = boto3.resource("s3", config=Config(signature_version=UNSIGNED))
+
+        return resource

--- a/tests/test_charge_density.py
+++ b/tests/test_charge_density.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from emmet.core.charge_density import ChgcarDataDoc
 from mp_api.routes.charge_density import ChargeDensityRester
 
 import inspect
@@ -98,7 +99,7 @@ def test_download_for_task_ids(tmpdir):
 def test_extract_s3_url_info():
     rester = resters[0]
 
-    url_doc = {
+    url_doc_dict = {
         "task_id": "mp-1896591",
         "url": "https://minio.materialsproject.org/phuck/atomate_chgcar_fs/6021584c12afbe14911d1b8e",
         "s3_url_prefix": "https://mp-volumetric.s3.amazonaws.com/atomate_chgcar_fs/",
@@ -106,6 +107,8 @@ def test_extract_s3_url_info():
         "requested_datetime": {"$date": {"$numberLong": "1650389943209"}},
         "expiry_datetime": None,
     }
+
+    url_doc = ChgcarDataDoc(**url_doc_dict)
 
     bucket, prefix = rester._extract_s3_url_info(url_doc)
 

--- a/tests/test_charge_density.py
+++ b/tests/test_charge_density.py
@@ -93,3 +93,26 @@ def test_download_for_task_ids(tmpdir):
     files = [f for f in os.listdir(tmpdir)]
 
     assert "mp-1791788.json.gz" in files
+
+
+def test_extract_s3_url_info():
+    rester = resters[0]
+
+    url_doc = {
+        "task_id": "mp-1896591",
+        "url": "https://minio.materialsproject.org/phuck/atomate_chgcar_fs/6021584c12afbe14911d1b8e",
+        "s3_url_prefix": "https://mp-volumetric.s3.amazonaws.com/atomate_chgcar_fs/",
+        "fs_id": "6021584c12afbe14911d1b8e",
+        "requested_datetime": {"$date": {"$numberLong": "1650389943209"}},
+        "expiry_datetime": None,
+    }
+
+    bucket, prefix = rester._extract_s3_url_info(url_doc)
+
+    assert bucket == "phuck"
+    assert prefix == "atomate_chgcar_fs"
+
+    bucket, prefix = rester._extract_s3_url_info(url_doc, use_minio=False)
+
+    assert bucket == "mp-volumetric"
+    assert prefix == "atomate_chgcar_fs"


### PR DESCRIPTION
This PR switches out direct GET requests to S3 object URLs for use of boto3. 