### PR TITLE
Ensure bucket name is present for AWS deployment

### DIFF
--- a/src/mp_api/routes/charge_density.py
+++ b/src/mp_api/routes/charge_density.py
@@ -88,7 +88,6 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
 
                 if self.boto_resource is None:
                     self.boto_resource = self._get_s3_resource(use_minio=False)
-                    
                     bucket, obj_prefix = self._extract_s3_url_info(
                         url_doc, use_minio=False
                     )

--- a/src/mp_api/routes/charge_density.py
+++ b/src/mp_api/routes/charge_density.py
@@ -88,6 +88,10 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
 
                 if self.boto_resource is None:
                     self.boto_resource = self._get_s3_resource(use_minio=False)
+                    
+                    bucket, obj_prefix = self._extract_s3_url_info(
+                        url_doc, use_minio=False
+                    )
 
             else:
                 try:


### PR DESCRIPTION
Fixes a bug where the bucket name was not being retrieved when the API client is used within an AWS deployment.