### PR TITLE
Add client side checks on material and task IDs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Test with pytest
         env:
           MP_API_KEY: ${{ secrets.MP_API_KEY }}
-          MP_API_ENDPOINT: https://api-preview.materialsproject.org/
+          #MP_API_ENDPOINT: https://api-preview.materialsproject.org/
         run: |
           pip install -e .
           pytest --cov=mp_api --cov-report=xml

--- a/src/mp_api/client.py
+++ b/src/mp_api/client.py
@@ -285,7 +285,10 @@ class MPRester:
         """
         return self.provenance.get_data_by_id(material_id).references
 
-    def get_materials_ids(self, chemsys_formula: Union[str, List[str]],) -> List[MPID]:
+    def get_materials_ids(
+        self,
+        chemsys_formula: Union[str, List[str]],
+    ) -> List[MPID]:
         """
         Get all materials ids for a formula or chemsys.
 
@@ -307,7 +310,9 @@ class MPRester:
         return sorted(
             doc.material_id
             for doc in self.materials.search_material_docs(
-                **input_params, all_fields=False, fields=["material_id"],  # type: ignore
+                **input_params,
+                all_fields=False,
+                fields=["material_id"],  # type: ignore
             )
         )
 
@@ -338,14 +343,18 @@ class MPRester:
             return [
                 doc.structure
                 for doc in self.materials.search_material_docs(
-                    **input_params, all_fields=False, fields=["structure"],  # type: ignore
+                    **input_params,
+                    all_fields=False,
+                    fields=["structure"],  # type: ignore
                 )
             ]
         else:
             structures = []
 
             for doc in self.materials.search_material_docs(
-                **input_params, all_fields=False, fields=["initial_structures"],  # type: ignore
+                **input_params,
+                all_fields=False,
+                fields=["initial_structures"],  # type: ignore
             ):
                 structures.extend(doc.initial_structures)
 
@@ -390,7 +399,9 @@ class MPRester:
         )
 
     def get_entries(
-        self, chemsys_formula: Union[str, List[str]], sort_by_e_above_hull=False,
+        self,
+        chemsys_formula: Union[str, List[str]],
+        sort_by_e_above_hull=False,
     ):
         """
         Get a list of ComputedEntries or ComputedStructureEntries corresponding
@@ -429,7 +440,9 @@ class MPRester:
 
         else:
             for doc in self.thermo.search_thermo_docs(
-                **input_params, all_fields=False, fields=["entries"],  # type: ignore
+                **input_params,
+                all_fields=False,
+                fields=["entries"],  # type: ignore
             ):
                 entries.extend(list(doc.entries.values()))
 
@@ -757,7 +770,9 @@ class MPRester:
         )
 
     def get_entries_in_chemsys(
-        self, elements: Union[str, List[str]], use_gibbs: Optional[int] = None,
+        self,
+        elements: Union[str, List[str]],
+        use_gibbs: Optional[int] = None,
     ):
         """
         Helper method to get a list of ComputedEntries in a chemical system.

--- a/src/mp_api/client.py
+++ b/src/mp_api/client.py
@@ -310,9 +310,9 @@ class MPRester:
         return sorted(
             doc.material_id
             for doc in self.materials.search_material_docs(
-                **input_params,
+                **input_params,  # type: ignore
                 all_fields=False,
-                fields=["material_id"],  # type: ignore
+                fields=["material_id"],
             )
         )
 
@@ -352,9 +352,9 @@ class MPRester:
             structures = []
 
             for doc in self.materials.search_material_docs(
-                **input_params,
+                **input_params,  # type: ignore
                 all_fields=False,
-                fields=["initial_structures"],  # type: ignore
+                fields=["initial_structures"],
             ):
                 structures.extend(doc.initial_structures)
 
@@ -440,9 +440,9 @@ class MPRester:
 
         else:
             for doc in self.thermo.search_thermo_docs(
-                **input_params,
+                **input_params,  # type: ignore
                 all_fields=False,
-                fields=["entries"],  # type: ignore
+                fields=["entries"],
             ):
                 entries.extend(list(doc.entries.values()))
 

--- a/src/mp_api/client.py
+++ b/src/mp_api/client.py
@@ -343,9 +343,9 @@ class MPRester:
             return [
                 doc.structure
                 for doc in self.materials.search_material_docs(
-                    **input_params,
+                    **input_params,  # type: ignore
                     all_fields=False,
-                    fields=["structure"],  # type: ignore
+                    fields=["structure"],
                 )
             ]
         else:

--- a/src/mp_api/core/utils.py
+++ b/src/mp_api/core/utils.py
@@ -14,7 +14,7 @@ def validate_ids(id_list: List[str]):
     Returns:
         id_list: Returns original ID list if everything is formatted correctly.
     """
-    pattern = "(mp|mvc)-.*"
+    pattern = "(mp|mvc|mol)-.*"
 
     for entry in id_list:
         if re.match(pattern, entry) is None:

--- a/src/mp_api/core/utils.py
+++ b/src/mp_api/core/utils.py
@@ -1,0 +1,23 @@
+import re
+from typing import List
+
+
+def validate_ids(id_list: List[str]):
+    """Function to validate material and task IDs
+
+    Args:
+        id_list (List[str]): List of material or task IDs.
+
+    Raises:
+        ValueError: If at least one ID is not formatted correctly.
+
+    Returns:
+        id_list: Returns original ID list if everything is formatted correctly.
+    """
+    pattern = "(mp|mvc)-.*"
+
+    for entry in id_list:
+        if re.match(pattern, entry) is None:
+            raise ValueError(f"{entry} is not formatted correctly!")
+
+    return id_list

--- a/src/mp_api/routes/charge_density.py
+++ b/src/mp_api/routes/charge_density.py
@@ -22,7 +22,7 @@ from mp_api.core.client import BaseRester
 class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
 
     suffix = "charge_density"
-    primary_key = "task_id"
+    primary_key = "fs_id"
     document_model = ChgcarDataDoc  # type: ignore
     boto_resource = None
 
@@ -87,11 +87,11 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
             if environ.get("AWS_EXECUTION_ENV", None) == "AWS_ECS_FARGATE":
 
                 if self.boto_resource is None:
-                    self.boto_resource = self._get_s3_resource(use_minio=False, unsigned=False)
+                    self.boto_resource = self._get_s3_resource(
+                        use_minio=False, unsigned=False
+                    )
 
-                bucket, obj_prefix = self._extract_s3_url_info(
-                    url_doc, use_minio=False
-                )
+                bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
 
             else:
                 try:

--- a/src/mp_api/routes/grain_boundary.py
+++ b/src/mp_api/routes/grain_boundary.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Tuple
 from collections import defaultdict
 
 from mp_api.core.client import BaseRester
+from mp_api.core.utils import validate_ids
 
 from emmet.core.grain_boundary import GBTypeEnum, GrainBoundaryDoc
 
@@ -58,7 +59,7 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
         query_params = defaultdict(dict)  # type: dict
 
         if material_ids:
-            query_params.update({"task_ids": ",".join(material_ids)})
+            query_params.update({"task_ids": ",".join(validate_ids(material_ids))})
 
         if gb_plane:
             query_params.update({"gb_plane": ",".join([str(n) for n in gb_plane])})

--- a/src/mp_api/routes/materials.py
+++ b/src/mp_api/routes/materials.py
@@ -1,9 +1,8 @@
 from typing import List, Optional, Tuple, Union
 from pymatgen.core.structure import Structure
 
-from emmet.core.material import MaterialsDoc
+from emmet.core.vasp.material import MaterialsDoc
 from emmet.core.symmetry import CrystalSystem
-from emmet.core.utils import jsanitize
 from emmet.core.settings import EmmetSettings
 
 from mp_api.core.client import BaseRester, MPRestError

--- a/src/mp_api/routes/materials.py
+++ b/src/mp_api/routes/materials.py
@@ -7,6 +7,7 @@ from emmet.core.utils import jsanitize
 from emmet.core.settings import EmmetSettings
 
 from mp_api.core.client import BaseRester, MPRestError
+from mp_api.core.utils import validate_ids
 
 _EMMET_SETTINGS = EmmetSettings()
 
@@ -107,7 +108,7 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if task_ids:
-            query_params.update({"task_ids": ",".join(task_ids)})
+            query_params.update({"task_ids": ",".join(validate_ids(task_ids))})
 
         query_params.update(
             {

--- a/src/mp_api/routes/summary.py
+++ b/src/mp_api/routes/summary.py
@@ -5,6 +5,7 @@ from emmet.core.mpid import MPID
 from emmet.core.summary import HasProps, SummaryDoc
 from emmet.core.symmetry import CrystalSystem
 from mp_api.core.client import BaseRester
+from mp_api.core.utils import validate_ids
 from pymatgen.analysis.magnetism import Ordering
 
 
@@ -42,9 +43,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
         magnetic_ordering: Optional[Ordering] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[
-            Tuple[float, float]
-        ] = None,
+        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
         num_magnetic_sites: Optional[Tuple[int, int]] = None,
         num_unique_magnetic_sites: Optional[Tuple[int, int]] = None,
         k_voigt: Optional[Tuple[float, float]] = None,
@@ -200,7 +199,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
                 )
 
         if material_ids:
-            query_params.update({"material_ids": ",".join(material_ids)})
+            query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if deprecated is not None:
             query_params.update({"deprecated": deprecated})
@@ -253,20 +252,10 @@ class SummaryRester(BaseRester[SummaryDoc]):
             query_params.update({"theoretical": theoretical})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super().search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/src/mp_api/routes/thermo.py
+++ b/src/mp_api/routes/thermo.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import Optional, List, Tuple, Union
 from mp_api.core.client import BaseRester
+from mp_api.core.utils import validate_ids
 from emmet.core.thermo import ThermoDoc
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 
@@ -71,7 +72,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
             query_params.update({"chemsys": ",".join(chemsys)})
 
         if material_ids:
-            query_params.update({"material_ids": ",".join(material_ids)})
+            query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if nelements:
             query_params.update(

--- a/src/mp_api/routes/xas.py
+++ b/src/mp_api/routes/xas.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Union
 
 from emmet.core.xas import Edge, XASDoc
 from mp_api.core.client import BaseRester
+from mp_api.core.utils import validate_ids
 from pymatgen.core.periodic_table import Element
 
 
@@ -67,7 +68,7 @@ class XASRester(BaseRester[XASDoc]):
             query_params.update({"elements": ",".join(elements)})
 
         if material_ids is not None:
-            query_params["material_ids"] = ",".join(material_ids)
+            query_params["material_ids"] = ",".join(validate_ids(material_ids))
 
         if sort_fields:
             query_params.update(


### PR DESCRIPTION
This PR adds formatting checks to all `material_id` and `task_id` values used in both single document  and general search queries. 