### PR TITLE
Pourbaix: fix filtering extra elements

### DIFF
--- a/src/mp_api/client.py
+++ b/src/mp_api/client.py
@@ -15,7 +15,7 @@ from mpcontribs.client import Client
 from pymatgen.analysis.magnetism import Ordering
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry
-from pymatgen.core import Element, Structure
+from pymatgen.core import Element, Structure, Composition
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedEntry
 from pymatgen.io.vasp import Chgcar
@@ -553,7 +553,7 @@ class MPRester:
         pbx_entries = [PourbaixEntry(e, f"ion-{n}") for n, e in enumerate(ion_entries)]
 
         # Construct the solid pourbaix entries from filtered ion_ref entries
-        ion_ref_comps = [e.composition for e in ion_entries]
+        ion_ref_comps = [Composition(d["data"]["RefSolid"]) for d in ion_data]
         ion_ref_elts = list(
             itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
         )

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -170,7 +170,12 @@ class TestMPRester:
         with pytest.raises(ValueError, match="Solid compatibility can only be"):
             mpr.get_pourbaix_entries("Ti-O", solid_compat=None)
 
-        # TODO - old tests copied from pymatgen. Update or delete
+        # test removal of extra elements from reference solids
+        # Li-Zn-S has Na in reference solids
+        pbx_entries = mpr.get_pourbaix_entries("Li-Zn-S")
+        assert not any([e for e in pbx_entries if 'Na' in e.composition])
+
+        # TODO - old tests copied from pymatgen with specific energy values. Update or delete
         # fe_two_plus = [e for e in pbx_entries if e.entry_id == "ion-0"][0]
         # self.assertAlmostEqual(fe_two_plus.energy, -1.12369, places=3)
         #


### PR DESCRIPTION
Fixes bug in which `get_pourbaix_entries` was not properly filtering out extra elements (i.e., solid entries included in the internal phase diagram because they are reference solids for ions, but that are not part of the originally-supplied chemical system)

## Contributor Checklist
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
