### PR TITLE
disable requests.Session.trus_env on default

### DIFF
--- a/src/mp_api/core/client.py
+++ b/src/mp_api/core/client.py
@@ -126,7 +126,6 @@ class BaseRester(Generic[T]):
     @staticmethod
     def _create_session(api_key, include_user_agent):
         session = requests.Session()
-        session.trust_env = False
         session.headers = {"x-api-key": api_key}
         if include_user_agent:
             pymatgen_info = "pymatgen/" + pmg_version


### PR DESCRIPTION
## Summary

Disable `requests.Session.trust_env` on default to use HTTP_PROXY/HTTPS_PROXY env and avoid unexpected behavior.
Please let me know if any specific reason exists to need `requests.Session.trust_env=true` on default.

see: [requests.Session.trust_env](https://requests.readthedocs.io/en/latest/api/?highlight=trust_env#requests.Session.trust_env)

## Background

We have an application running behind a HTTP proxy using HTTP_PROXY and HTTPS_PROXY env because of security purpose. We tried to use mp-api, then we observed the client use the proxy for `contribs-api.materialsproject.org` endpoint, but doesn't use the proxy for `api.materialsproject.org`. After the investigation, we found `requests.Session.trus_env=false` ignore the environment variables of proxy servers.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] disable `requests.Session.trus_env` on default
- [x] I have run the tests locally and they passed. I have run the tests.: It seems 1 failed test exists on main branch.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.: This is very small fix, and doesn't break existing tests.
