### PR TITLE
Add exclude elements to list of non-parallel

### DIFF
--- a/src/mp_api/core/settings.py
+++ b/src/mp_api/core/settings.py
@@ -18,6 +18,7 @@ class MAPIClientSettings(BaseSettings):
     QUERY_NO_PARALLEL: List[str] = Field(
         [
             "elements",
+            "exclude_elements",
             "possible_species",
             "coordination_envs",
             "coordination_envs_anonymous",


### PR DESCRIPTION
Fixes issues with `exclude_elements` queries not returning correct results due to incorrect requests parallelization. 