### PR TITLE
Add custodian as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ maggma==0.47.4
 requests==2.27.1
 monty==2022.3.12
 mpcontribs-client>=4.2.9
+custodian>=2022.5.26
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ maggma==0.47.4
 requests==2.27.1
 monty==2022.3.12
 mpcontribs-client>=4.2.9
-custodian>=2022.5.26
+custodian
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "monty>=2021.3.12",
         "emmet-core>=0.32.3",
         "maggma>=0.47.4",
-        "custodian"
+        "custodian",
         "mpcontribs-client",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "monty>=2021.3.12",
         "emmet-core>=0.32.3",
         "maggma>=0.47.4",
+        "custodian>=2022.5.26"
         "mpcontribs-client",
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "monty>=2021.3.12",
         "emmet-core>=0.32.3",
         "maggma>=0.47.4",
-        "custodian>=2022.5.26"
+        "custodian"
         "mpcontribs-client",
     ],
     classifiers=[


### PR DESCRIPTION
This fixes de-serialization issues with certain data in `TaskDoc` objects.