### PR TITLE
Clean up dependencies

### DIFF
--- a/mp_api/client/client.py
+++ b/mp_api/client/client.py
@@ -951,7 +951,7 @@ class MPRester:
         Returns:
             chgcar: Pymatgen Chgcar object.
         """
-        
+
         if not hasattr(self, "charge_density"):
             raise MPRestError("boto3 not installed. "
                   "To query charge density data install the boto3 package.")

--- a/mp_api/client/client.py
+++ b/mp_api/client/client.py
@@ -939,6 +939,10 @@ class MPRester:
         Returns:
             chgcar: Pymatgen Chgcar object.
         """
+        
+        if not hasattr(self, "charge_density"):
+            raise MPRestError("boto3 not installed. "
+                  "To query charge density data install the boto3 package.")
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity

--- a/mp_api/client/client.py
+++ b/mp_api/client/client.py
@@ -134,6 +134,10 @@ class MPRester:
         try:
             from mpcontribs.client import Client
             self.contribs = Client(api_key)
+        except ImportError:
+            self.contribs = None
+            warnings.warn("mpcontribs-client not installed. "
+                          "Install the package o query MPContribs data, or construct pourbaix diagrams.")
         except Exception as error:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")
@@ -180,10 +184,10 @@ class MPRester:
     def __getattr__(self, attr):
         if attr == "alloys":
             raise MPRestError("Alloy addon package not installed. "
-                              "To query alloy data install the pymatgen-analysis-alloys package.")
+                              "To query alloy data first install with: 'pip install pymatgen-analysis-alloys'")
         elif attr == "charge_density":
             raise MPRestError("boto3 not installed. "
-                              "To query charge density data install the boto3 package.")
+                              "To query charge density data first install with: 'pip install boto3'")
         else:
             raise AttributeError(
                     f"{self.__class__.__name__!r} object has no attribute {attr!r}"

--- a/mp_api/client/client.py
+++ b/mp_api/client/client.py
@@ -11,7 +11,6 @@ from emmet.core.settings import EmmetSettings
 from emmet.core.summary import HasProps
 from emmet.core.symmetry import CrystalSystem
 from emmet.core.vasp.calc_types import CalcType
-from mpcontribs.client import Client
 from pymatgen.analysis.magnetism import Ordering
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry
@@ -133,6 +132,7 @@ class MPRester:
         )
 
         try:
+            from mpcontribs.client import Client
             self.contribs = Client(api_key)
         except Exception as error:
             self.contribs = None

--- a/mp_api/client/client.py
+++ b/mp_api/client/client.py
@@ -177,6 +177,18 @@ class MPRester:
         """
         self.session.close()
 
+    def __getattr__(self, attr):
+        if attr == "alloys":
+            raise MPRestError("Alloy addon package not installed. "
+                              "To query alloy data install the pymatgen-analysis-alloys package.")
+        elif attr == "charge_density":
+            raise MPRestError("boto3 not installed. "
+                              "To query charge density data install the boto3 package.")
+        else:
+            raise AttributeError(
+                    f"{self.__class__.__name__!r} object has no attribute {attr!r}"
+                )
+
     def get_task_ids_associated_with_material_id(
         self, material_id: str, calc_types: Optional[List[CalcType]] = None
     ) -> List[str]:

--- a/mp_api/client/client.py
+++ b/mp_api/client/client.py
@@ -137,7 +137,8 @@ class MPRester:
         except ImportError:
             self.contribs = None
             warnings.warn("mpcontribs-client not installed. "
-                          "Install the package o query MPContribs data, or construct pourbaix diagrams.")
+                          "Install the package to query MPContribs data, or construct pourbaix diagrams: "
+                          "'pip install mpcontribs-client'")
         except Exception as error:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")

--- a/mp_api/client/core/client.py
+++ b/mp_api/client/core/client.py
@@ -19,7 +19,6 @@ from urllib.parse import urljoin
 
 import requests
 from emmet.core.utils import jsanitize
-from maggma.api.utils import api_sanitize
 from monty.json import MontyDecoder
 from pydantic import BaseModel, create_model
 from requests.adapters import HTTPAdapter
@@ -28,7 +27,7 @@ from tqdm.auto import tqdm
 from urllib3.util.retry import Retry
 
 from mp_api.client.core.settings import MAPIClientSettings
-from mp_api.client.core.utils import validate_ids
+from mp_api.client.core.utils import validate_ids, api_sanitize
 
 try:
     from pymatgen.core import __version__ as pmg_version  # type: ignore

--- a/mp_api/client/core/utils.py
+++ b/mp_api/client/core/utils.py
@@ -1,5 +1,10 @@
 import re
-from typing import List
+from typing import List, Optional, Type, get_args
+
+from monty.json import MSONable
+from pydantic import BaseModel
+from pydantic.schema import get_flat_models_from_model
+from pydantic.utils import lenient_issubclass
 
 
 def validate_ids(id_list: List[str]):
@@ -21,3 +26,89 @@ def validate_ids(id_list: List[str]):
             raise ValueError(f"{entry} is not formatted correctly!")
 
     return id_list
+
+
+def api_sanitize(
+    pydantic_model: Type[BaseModel],
+    fields_to_leave: Optional[List[str]] = None,
+    allow_dict_msonable=False,
+):
+    """
+    Function to clean up pydantic models for the API by:
+        1.) Making fields optional
+        2.) Allowing dictionaries in-place of the objects for MSONable quantities
+
+    WARNING: This works in place, so it mutates the model and all sub-models
+
+    Args:
+        fields_to_leave: list of strings for model fields as "model__name__.field"
+    """
+
+    models = [
+        model
+        for model in get_flat_models_from_model(pydantic_model)
+        if issubclass(model, BaseModel)
+    ]  # type: List[Type[BaseModel]]
+
+    fields_to_leave = fields_to_leave or []
+    fields_tuples = [f.split(".") for f in fields_to_leave]
+    assert all(len(f) == 2 for f in fields_tuples)
+
+    for model in models:
+        model_fields_to_leave = {f[1] for f in fields_tuples if model.__name__ == f[0]}
+        for name, field in model.__fields__.items():
+            field_type = field.type_
+
+            if name not in model_fields_to_leave:
+                field.required = False
+                field.default = None
+                field.default_factory = None
+                field.allow_none = True
+                field.field_info.default = None
+                field.field_info.default_factory = None
+
+            if field_type is not None and allow_dict_msonable:
+                if lenient_issubclass(field_type, MSONable):
+                    field.type_ = allow_msonable_dict(field_type)
+                else:
+                    for sub_type in get_args(field_type):
+                        if lenient_issubclass(sub_type, MSONable):
+                            allow_msonable_dict(sub_type)
+                field.populate_validators()
+
+    return pydantic_model
+
+
+def allow_msonable_dict(monty_cls: Type[MSONable]):
+    """
+    Patch Monty to allow for dict values for MSONable
+    """
+
+    def validate_monty(cls, v):
+        """
+        Stub validator for MSONable as a dictionary only
+        """
+        if isinstance(v, cls):
+            return v
+        elif isinstance(v, dict):
+            # Just validate the simple Monty Dict Model
+            errors = []
+            if v.get("@module", "") != monty_cls.__module__:
+                errors.append("@module")
+
+            if v.get("@class", "") != monty_cls.__name__:
+                errors.append("@class")
+
+            if len(errors) > 0:
+                raise ValueError(
+                    "Missing Monty seriailzation fields in dictionary: {errors}"
+                )
+
+            return v
+        else:
+            raise ValueError(f"Must provide {cls.__name__} or MSONable dictionary")
+
+    setattr(monty_cls, "validate_monty", classmethod(validate_monty))
+
+    return monty_cls
+

--- a/mp_api/client/core/utils.py
+++ b/mp_api/client/core/utils.py
@@ -111,4 +111,3 @@ def allow_msonable_dict(monty_cls: Type[MSONable]):
     setattr(monty_cls, "validate_monty", classmethod(validate_monty))
 
     return monty_cls
-

--- a/mp_api/client/routes/__init__.py
+++ b/mp_api/client/routes/__init__.py
@@ -1,3 +1,4 @@
+from ast import Import
 from .eos import EOSRester
 from .materials import MaterialsRester
 from .similarity import SimilarityRester
@@ -15,7 +16,6 @@ from .doi import DOIRester
 from .piezo import PiezoRester
 from .magnetism import MagnetismRester
 from .summary import SummaryRester
-from .robocrys import RobocrysRester
 from .molecules import MoleculesRester
 from .synthesis import SynthesisRester
 from .electrodes import ElectrodeRester
@@ -30,4 +30,11 @@ from .provenance import ProvenanceRester
 from ._user_settings import UserSettingsRester
 from ._general_store import GeneralStoreRester
 from .bonds import BondsRester
-from .alloys import AlloysRester
+from .robocrys import RobocrysRester
+
+try:
+    from .alloys import AlloysRester
+except ImportError:
+    import warnings
+    warnings.warn("Alloy addon package not installed. To query alloy data install the pymatgen-analysis-alloys package.")
+    AlloysRester = None  # type: ignore

--- a/mp_api/client/routes/__init__.py
+++ b/mp_api/client/routes/__init__.py
@@ -36,5 +36,6 @@ try:
     from .alloys import AlloysRester
 except ImportError:
     import warnings
-    warnings.warn("Alloy addon package not installed. To query alloy data install the pymatgen-analysis-alloys package.")
+    warnings.warn("Alloy addon package not installed. "
+                  "To query alloy data install the pymatgen-analysis-alloys package.")
     AlloysRester = None  # type: ignore

--- a/mp_api/client/routes/__init__.py
+++ b/mp_api/client/routes/__init__.py
@@ -34,15 +34,9 @@ from .robocrys import RobocrysRester
 try:
     from .alloys import AlloysRester
 except ImportError:
-    import warnings
-    warnings.warn("Alloy addon package not installed. "
-                  "To query alloy data install the pymatgen-analysis-alloys package.")
     AlloysRester = None  # type: ignore
 
 try:
     from .charge_density import ChargeDensityRester
 except ImportError:
-    import warnings
-    warnings.warn("boto3 not installed. "
-                  "To query charge density data install the boto3 package.")
     ChargeDensityRester = None  # type: ignore

--- a/mp_api/client/routes/__init__.py
+++ b/mp_api/client/routes/__init__.py
@@ -19,7 +19,6 @@ from .summary import SummaryRester
 from .molecules import MoleculesRester
 from .synthesis import SynthesisRester
 from .electrodes import ElectrodeRester
-from .charge_density import ChargeDensityRester
 from .electronic_structure import (
     ElectronicStructureRester,
     BandStructureRester,
@@ -39,3 +38,11 @@ except ImportError:
     warnings.warn("Alloy addon package not installed. "
                   "To query alloy data install the pymatgen-analysis-alloys package.")
     AlloysRester = None  # type: ignore
+
+try:
+    from .charge_density import ChargeDensityRester
+except ImportError:
+    import warnings
+    warnings.warn("boto3 not installed. "
+                  "To query charge density data install the boto3 package.")
+    ChargeDensityRester = None  # type: ignore

--- a/mp_api/client/routes/alloys.py
+++ b/mp_api/client/routes/alloys.py
@@ -5,8 +5,6 @@ from mp_api.client.core import BaseRester
 from mp_api.client.core.utils import validate_ids
 from emmet.core.alloys import AlloyPairDoc
 
-import warnings
-
 
 class AlloysRester(BaseRester[AlloyPairDoc]):
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-emmet-core==0.32.3
+emmet-core[all]==0.35.0
 pydantic>=1.8.2
 pymatgen>=2022.3.7
 pymatgen-analysis-alloys>=0.0.3
 typing-extensions==4.1.1
-maggma==0.47.4
 requests==2.27.1
 monty==2022.3.12
 mpcontribs-client>=4.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ requests==2.27.1
 monty==2022.3.12
 mpcontribs-client>=4.2.9
 custodian
+boto3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-emmet-core[all]==0.35.0
+emmet-core[all]==0.35.1
 pydantic>=1.8.2
 pymatgen>=2022.3.7
 pymatgen-analysis-alloys>=0.0.3

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     ],
     extras_require={
         "all": [
+            "emmet-core[all]>=0.35.0"
             "custodian",
             "mpcontribs-client",
         ],

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ setup(
         "typing-extensions>=3.7.4.1",
         "requests>=2.23.0",
         "monty>=2021.3.12",
-        "emmet-core>=0.35.0",
+        "emmet-core>=0.35.1",
     ],
     extras_require={
         "all": [
-            "emmet-core[all]>=0.35.0"
+            "emmet-core[all]>=0.35.1"
             "custodian",
             "mpcontribs-client",
         ],

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             "emmet-core[all]>=0.35.1"
             "custodian",
             "mpcontribs-client",
+            "boto3"
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,14 @@ setup(
         "typing-extensions>=3.7.4.1",
         "requests>=2.23.0",
         "monty>=2021.3.12",
-        "emmet-core>=0.32.3",
-        "maggma>=0.47.4",
-        "custodian",
-        "mpcontribs-client",
+        "emmet-core>=0.35.0",
     ],
+    extras_require={
+        "all": [
+            "custodian",
+            "mpcontribs-client",
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
- `custodian`, `mpcontribs-client`, `boto3`, and `emmet-core[all]` made optional dependencies
- `AlloyRester` import altered with warning to handle when `pymatgen-analysis-alloys` is not installed via `emmet-core`