### PR TITLE
Support single values instead of (min, max) tuples as summary search filters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,11 @@ repos:
     -   id: trailing-whitespace
     -   id: flake8
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.8.0
     hooks:
     - id: black
       language_version: python3 # Should be a command that runs python3.6+
-  - repo: https://github.com/myint/autoflake
-    rev: v1.4
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v1.5.3
     hooks:
     - id: autoflake
-      args: [--in-place, --remove-all-unused-imports, --remove-unused-variable]

--- a/mp_api/client/routes/electrodes.py
+++ b/mp_api/client/routes/electrodes.py
@@ -131,6 +131,8 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
             query_params.update({"elements": ",".join(elements)})
 
         if num_elements:
+            if isinstance(num_elements, int):
+                num_elements = (num_elements, num_elements)
             query_params.update(
                 {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
             )

--- a/mp_api/client/routes/electronic_structure.py
+++ b/mp_api/client/routes/electronic_structure.py
@@ -1,4 +1,5 @@
 import base64
+import warnings
 import zlib
 from collections import defaultdict
 from typing import List, Optional, Tuple, Union
@@ -10,13 +11,12 @@ from emmet.core.electronic_structure import (
     ElectronicStructureDoc,
 )
 from monty.serialization import MontyDecoder
-from mp_api.client.core import BaseRester, MPRestError
-from mp_api.client.core.utils import validate_ids
 from pymatgen.analysis.magnetism.analyzer import Ordering
 from pymatgen.core.periodic_table import Element
 from pymatgen.electronic_structure.core import OrbitalType, Spin
 
-import warnings
+from mp_api.client.core import BaseRester, MPRestError
+from mp_api.client.core.utils import validate_ids
 
 
 class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
@@ -126,6 +126,8 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"magnetic_ordering": magnetic_ordering.value})
 
         if num_elements:
+            if isinstance(num_elements, int):
+                num_elements = (num_elements, num_elements)
             query_params.update(
                 {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
             )

--- a/mp_api/client/routes/materials.py
+++ b/mp_api/client/routes/materials.py
@@ -1,14 +1,13 @@
+import warnings
 from typing import List, Optional, Tuple, Union
-from pymatgen.core.structure import Structure
 
-from emmet.core.vasp.material import MaterialsDoc
-from emmet.core.symmetry import CrystalSystem
 from emmet.core.settings import EmmetSettings
+from emmet.core.symmetry import CrystalSystem
+from emmet.core.vasp.material import MaterialsDoc
+from pymatgen.core.structure import Structure
 
 from mp_api.client.core import BaseRester, MPRestError
 from mp_api.client.core.utils import validate_ids
-
-import warnings
 
 _EMMET_SETTINGS = EmmetSettings()
 
@@ -154,6 +153,8 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
             )
 
         if num_elements:
+            if isinstance(num_elements, int):
+                num_elements = (num_elements, num_elements)
             query_params.update(
                 {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
             )

--- a/mp_api/client/routes/summary.py
+++ b/mp_api/client/routes/summary.py
@@ -1,14 +1,14 @@
+import warnings
 from collections import defaultdict
 from typing import List, Optional, Tuple, Union
 
 from emmet.core.mpid import MPID
 from emmet.core.summary import HasProps, SummaryDoc
 from emmet.core.symmetry import CrystalSystem
-from mp_api.client.core import BaseRester
-from mp_api.client.core.utils import validate_ids
 from pymatgen.analysis.magnetism import Ordering
 
-import warnings
+from mp_api.client.core import BaseRester
+from mp_api.client.core.utils import validate_ids
 
 
 class SummaryRester(BaseRester[SummaryDoc]):
@@ -210,6 +210,8 @@ class SummaryRester(BaseRester[SummaryDoc]):
 
         for param, value in locals().items():
             if param in min_max_name_dict and value:
+                if isinstance(value, (int, float)):
+                    value = (value, value)
                 query_params.update(
                     {
                         f"{min_max_name_dict[param]}_min": value[0],
@@ -289,5 +291,5 @@ class SummaryRester(BaseRester[SummaryDoc]):
             chunk_size=chunk_size,
             all_fields=all_fields,
             fields=fields,
-            **query_params
+            **query_params,
         )

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -1,11 +1,12 @@
+import warnings
 from collections import defaultdict
-from typing import Optional, List, Tuple, Union
-from mp_api.client.core import BaseRester
-from mp_api.client.core.utils import validate_ids
+from typing import List, Optional, Tuple, Union
+
 from emmet.core.thermo import ThermoDoc
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 
-import warnings
+from mp_api.client.core import BaseRester
+from mp_api.client.core.utils import validate_ids
 
 
 class ThermoRester(BaseRester[ThermoDoc]):
@@ -95,6 +96,8 @@ class ThermoRester(BaseRester[ThermoDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if num_elements:
+            if isinstance(num_elements, int):
+                num_elements = (num_elements, num_elements)
             query_params.update(
                 {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,10 +2,10 @@
 addopts = --durations=30
 
 [pycodestyle]
-count = True
+count = true
 ignore = E121,E123,E126,E133,E226,E241,E242,E704,W503,W504,W505,E741,W605,W293,E203
 max-line-length = 120
-statistics = True
+statistics = true
 exclude = documentation.py
 
 [flake8]
@@ -18,4 +18,11 @@ max-line-length = 120
 ignore = D105,D2,D4
 
 [mypy]
-ignore_missing_imports = True
+ignore_missing_imports = true
+
+[autoflake]
+in-place = true
+remove-unused-variables = true
+remove-all-unused-imports = true
+expand-star-imports = true
+ignore-init-module-imports = true


### PR DESCRIPTION
This query currently errors

```
from pymatgen.ext.matproj import MPRester

MPRester().summary.search(
    num_elements=1, fields=["material_id", "pretty_formula", "energy_per_atom"]
)
```

with

```py
TypeError: 'int' object is not subscriptable
```

since it should be `num_elements=[1, 1]` instead of `num_elements=1`.

The error message isn't very clear so one improvement might be to ask the user to pass a tuple instead. This PR instead converts the value to a tuple on the fly when detecting `int`:

```py
if isinstance(num_elements, int):
    num_elements = (num_elements, num_elements)
```

In the case of summary.search, it converts all values to tuple when detecting `int` or `float`.

```py
        for param, value in locals().items():
            if param in min_max_name_dict and value:
                if isinstance(value, (int, float)):
                    value = (value, value)
```

Let me know if that's an acceptable change?