### PR TITLE
Use six API keys in testing workflow instead of one

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Format API key name
         run: |
           export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} | awk '{gsub(/-|\./, "_"); print}')
-          echo "::set-env name=API_KEY_NAME::$API_KEY_NAME"
+          echo echo ("API_KEY_NAME="$API_KEY_NAME) >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : "echo $API_KEY_NAME"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')"
+        run: echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,7 +81,7 @@ jobs:
           echo "API_KEY_NAME="$API_KEY_NAME >> $env:GITHUB_ENV
       
       - name : machine echo test
-        run : echo ${{ env.API_KEY_NAME }}
+        run : "echo ${{ env.API_KEY_NAME }}"
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,15 +69,21 @@ jobs:
 
       - name: Set SSL_CERT_FILE (Linux)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: export SSL_CERT_FILE=$(python -m certifi)
+        run: echo "SSL_CERT_FILE=$(python -m certifi)" >> $GITHUB_ENV
 
       - name: Set SSL_CERT_FILE (Windows)
         if: matrix.os == 'windows-latest'
-        run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
+        run: echo "SSL_CERT_FILE=$(python -m certifi)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       
-      - name: Format API key name
+      - name: Format API key name (Linux/MacOS)
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
+
+      - name: Format API key name (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,6 +77,7 @@ jobs:
       
       - name: Format API key name
         run: |
+          echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}'
           export API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')
           echo API_KEY_NAME=$API_KEY_NAME >> $env:GITHUB_ENV
       

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,6 +75,10 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
 
+      - name : machine echo test
+        env : { CONTENT : "${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }}" }
+        run : "echo $CONTENT"
+
       - name: Test with pytest
         env:
           MP_API_KEY: ${{ secrets[format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))] }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -84,10 +84,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-      
-      - name : machine echo test
-        run : |
-          echo '${{ toJSON(env) }}'
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,7 +81,7 @@ jobs:
           echo "API_KEY_NAME="$API_KEY_NAME >> $env:GITHUB_ENV
       
       - name : machine echo test
-        run : "echo $API_KEY_NAME"
+        run : echo ${{ env.API_KEY_NAME }}
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,8 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
+        run: |
+          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,10 +74,14 @@ jobs:
       - name: Set SSL_CERT_FILE (Windows)
         if: matrix.os == 'windows-latest'
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
-
+      
+      - name: Format API key name
+        run: |
+          export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} |  | awk '{gsub(/-|\./, "_"); print}')
+          echo "::set-env name=API_KEY_NAME::$API_KEY_NAME"
+      
       - name : machine echo test
-        env : { CONTENT : "${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }}" }
-        run : "echo $CONTENT"
+          run : "echo $API_KEY_NAME"
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,10 +78,11 @@ jobs:
       - name: Format API key name
         run: |
           export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} | awk '{gsub(/-|\./, "_"); print}')
-          echo "API_KEY_NAME="$API_KEY_NAME >> $env:GITHUB_ENV
+          echo ("API_KEY_NAME="$API_KEY_NAME) >> $env:GITHUB_ENV
       
       - name : machine echo test
-        run : "echo ${{ env.API_KEY_NAME }}"
+        run : |
+          echo ${{ env.API_KEY_NAME }}
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,14 +78,14 @@ jobs:
       - name: Format API key name
         run: |
           export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} | awk '{gsub(/-|\./, "_"); print}')
-          echo echo ("API_KEY_NAME="$API_KEY_NAME) >> $env:GITHUB_ENV
+          echo "API_KEY_NAME="$API_KEY_NAME >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : "echo $API_KEY_NAME"
 
       - name: Test with pytest
         env:
-          MP_API_KEY: ${{ secrets[format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))] }}
+          MP_API_KEY: ${{ secrets[env.API_KEY_NAME] }}
           #MP_API_ENDPOINT: https://api-preview.materialsproject.org/
         run: |
           pip install -e .

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Format API key name
         run: |
           export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} | awk '{gsub(/-|\./, "_"); print}')
-          echo ("API_KEY_NAME="$API_KEY_NAME) >> $env:GITHUB_ENV
+          echo ("API_KEY_NAME=" + $API_KEY_NAME) >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -81,7 +81,7 @@ jobs:
           echo "::set-env name=API_KEY_NAME::$API_KEY_NAME"
       
       - name : machine echo test
-          run : "echo $API_KEY_NAME"
+        run : "echo $API_KEY_NAME"
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -91,7 +91,7 @@ jobs:
           #MP_API_ENDPOINT: https://api-preview.materialsproject.org/
         run: |
           pip install -e .
-          pytest --cov=mp_api --cov-report=xml
+          pytest -x --cov=mp_api --cov-report=xml
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,9 +76,7 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: |
-          export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} | awk '{gsub(/-|\./, "_"); print}')
-          echo ("API_KEY_NAME=" + $API_KEY_NAME) >> $env:GITHUB_ENV
+        run: echo ("API_KEY_NAME=" + $(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')) >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: echo ("API_KEY_NAME=" + $(${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')) >> $env:GITHUB_ENV
+        run: echo "API_KEY_NAME=$(${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,7 +82,7 @@ jobs:
       
       - name : machine echo test
         run : |
-          echo ${{ env.API_KEY_NAME }}
+          echo '${{ toJSON(env) }}'
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Test with pytest
         env:
-          MP_API_KEY: ${{ secrets.MP_API_KEY }}
+          MP_API_KEY: ${{ secrets[format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))] }}
           #MP_API_ENDPOINT: https://api-preview.materialsproject.org/
         run: |
           pip install -e .

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $env:GITHUB_ENV
+        run: echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')"
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,10 +76,7 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: |
-          echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}'
-          export API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')
-          echo API_KEY_NAME=$API_KEY_NAME >> $env:GITHUB_ENV
+        run: echo ("API_KEY_NAME=" + $(${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')) >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,9 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: echo ("API_KEY_NAME=" + $(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')) >> $env:GITHUB_ENV
+        run: |
+          export API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')
+          echo API_KEY_NAME=$API_KEY_NAME >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,7 +77,7 @@ jobs:
       
       - name: Format API key name
         run: |
-          export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} |  | awk '{gsub(/-|\./, "_"); print}')
+          export API_KEY_NAME=$(echo ${{ toJson(format('MP_API_KEY_{0}_{1}', join(matrix.os, '-'), join(matrix.python-version, '.'))) }} | awk '{gsub(/-|\./, "_"); print}')
           echo "::set-env name=API_KEY_NAME::$API_KEY_NAME"
       
       - name : machine echo test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -76,7 +76,7 @@ jobs:
         run: echo ("SSL_CERT_FILE=" + $(python -m certifi)) >> $env:GITHUB_ENV
       
       - name: Format API key name
-        run: echo "API_KEY_NAME=$(${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $env:GITHUB_ENV
+        run: echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $env:GITHUB_ENV
       
       - name : machine echo test
         run : |


### PR DESCRIPTION
This PR adds multiple API keys to the testing workflow to avoid rate limit issues from the six parallel runs.