### PR TITLE
Ensure parity with top level legacy methods

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -463,7 +463,7 @@ class MPRester:
                 which performs adjustments to allow mixing of GGA and GGA+U
                 calculations for more accurate phase diagrams and reaction
                 energies. This data is obtained from the core "thermo" API endpoint.
-            inc_structure (str): This is a deprecated input. Previously, if None, entries
+            inc_structure (str): *This is a deprecated argument*. Previously, if None, entries
                 returned were ComputedEntries. If inc_structure="initial",
                 ComputedStructureEntries with initial structures were returned.
                 Otherwise, ComputedStructureEntries with final structures
@@ -863,7 +863,7 @@ class MPRester:
                 which performs adjustments to allow mixing of GGA and GGA+U
                 calculations for more accurate phase diagrams and reaction
                 energies. This data is obtained from the core "thermo" API endpoint.
-            inc_structure (str): *This is a deprecated input*. Previously, if None, entries
+            inc_structure (str): *This is a deprecated argument*. Previously, if None, entries
                 returned were ComputedEntries. If inc_structure="initial",
                 ComputedStructureEntries with initial structures were returned.
                 Otherwise, ComputedStructureEntries with final structures
@@ -913,7 +913,7 @@ class MPRester:
                 which performs adjustments to allow mixing of GGA and GGA+U
                 calculations for more accurate phase diagrams and reaction
                 energies. This data is obtained from the core "thermo" API endpoint.
-            inc_structure (str): *This is a deprecated input*. Previously, if None, entries
+            inc_structure (str): *This is a deprecated argument*. Previously, if None, entries
                 returned were ComputedEntries. If inc_structure="initial",
                 ComputedStructureEntries with initial structures were returned.
                 Otherwise, ComputedStructureEntries with final structures
@@ -924,7 +924,7 @@ class MPRester:
                 input parameters in the 'MPRester.thermo.available_fields' list.
             conventional_unit_cell (bool): Whether to get the standard
                 conventional unit cell
-            additional_criteria (dict): *This is a deprecated input*. To obtain entry objects
+            additional_criteria (dict): *This is a deprecated argument*. To obtain entry objects
                 with additional criteria, use the `MPRester.thermo.search` method directly.
         Returns:
             List of ComputedStructureEntries.

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -400,7 +400,7 @@ class MPRester:
                 structures.extend(doc.initial_structures)
 
             return structures
-    
+
     def find_structure(
         self,
         filename_or_structure: Union[str, Structure],
@@ -512,19 +512,19 @@ class MPRester:
             docs = self.thermo.search(
                 **input_params, all_fields=False, fields=fields,  # type: ignore
             )
-        
+
         for doc in docs:
             for entry in doc.entries.values():
                 if not compatible_only:
                     entry.correction = 0.0
                     entry.energy_adjustments = []
-                    
+
                 if property_data:
                     for property in property_data:
                         entry.data[property] = doc.dict()[property]
-                        
+
                 if conventional_unit_cell:
-        
+
                     s = SpacegroupAnalyzer(entry.structure).get_conventional_standard_structure()
                     site_ratio = (len(s) / len(entry.structure))
                     new_energy = entry.uncorrected_energy * site_ratio
@@ -539,9 +539,9 @@ class MPRester:
 
                     for correction in entry_dict["energy_adjustments"]:
                         correction["n_atoms"] *= site_ratio
-                        
+
                     entry = ComputedStructureEntry.from_dict(entry_dict)
-            
+
                 entries.append(entry)
 
         return entries

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -482,7 +482,7 @@ class MPRester:
         """
 
         if inc_structure is not None:
-            warnings.warn("The 'inc_structure' parameter is deprecated as structure "
+            warnings.warn("The 'inc_structure' argument is deprecated as structure "
                           "data is now always included in all returned entry objects.")
 
         if isinstance(chemsys_formula_mpids, str):
@@ -931,7 +931,7 @@ class MPRester:
         """
 
         if additional_criteria is not None:
-            warnings.warn("The 'additional_criteria' parameter is deprecated."
+            warnings.warn("The 'additional_criteria' argument is deprecated. "
                           "To obtain entry objects with additional criteria, use "
                           "the 'MPRester.thermo.search' method directly")
 

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -879,11 +879,20 @@ class MPRester:
             if conventional_unit_cell:
 
                 s = SpacegroupAnalyzer(entry.structure).get_conventional_standard_structure()
-                new_energy = entry.energy * (len(s) / len(entry.structure))
+                site_ratio = (len(s) / len(entry.structure))
+                new_energy = entry.uncorrected_energy * site_ratio
 
                 entry_dict = entry.as_dict()
                 entry_dict["energy"] = new_energy
                 entry_dict["structure"] = s.as_dict()
+                entry_dict["correction"] = None
+
+                for element in entry_dict["composition"]:
+                    entry_dict["composition"][element] *= site_ratio
+
+                for correction in entry_dict["energy_adjustments"]:
+                    correction["n_atoms"] *= site_ratio
+
                 entry = ComputedStructureEntry.from_dict(entry_dict)
 
             entries.append(entry)

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -851,6 +851,7 @@ class MPRester:
         inc_structure: bool = None,
         property_data: List[str] = None,
         conventional_unit_cell: bool = False,
+        additional_criteria=None,
     ):
         """
         Helper method to get a list of ComputedEntries in a chemical system.
@@ -873,7 +874,7 @@ class MPRester:
                 which performs adjustments to allow mixing of GGA and GGA+U
                 calculations for more accurate phase diagrams and reaction
                 energies. This data is obtained from the core "thermo" API endpoint.
-            inc_structure (str): This is a deprecated input. Previously, if None, entries
+            inc_structure (str): *This is a deprecated input*. Previously, if None, entries
                 returned were ComputedEntries. If inc_structure="initial",
                 ComputedStructureEntries with initial structures were returned.
                 Otherwise, ComputedStructureEntries with final structures
@@ -884,9 +885,17 @@ class MPRester:
                 input parameters in the 'MPRester.thermo.available_fields' list.
             conventional_unit_cell (bool): Whether to get the standard
                 conventional unit cell
+            additional_criteria (dict): *This is a deprecated input*. To obtain entry objects
+                with additional criteria, use the `MPRester.thermo.search` method directly.
         Returns:
-            List of ComputedEntries.
+            List of ComputedStructureEntries.
         """
+        
+        if additional_criteria is not None:
+            warnings.warn("The 'additional_criteria' parameter is deprecated."
+                          "To obtain entry objects with additional criteria, use "
+                          "the 'MPRester.thermo.search' method directly")
+        
         if isinstance(elements, str):
             elements = elements.split("-")
 

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -90,7 +90,6 @@ class TestMPRester:
         structs = mpr.get_structures("Mn-O", final=False)
         assert len(structs) > 0
 
-    @pytest.mark.skip(reason="endpoint issues")
     def test_find_structure(self, mpr):
         path = os.path.join(MAPIClientSettings().TEST_FILES, "Si_mp_149.cif")
         with open(path) as file:
@@ -136,28 +135,28 @@ class TestMPRester:
 
         for e in entries:
             assert isinstance(e, ComputedEntry)
-            
+
         # Property data
         formula = "BiFeO3"
         entries = mpr.get_entries(formula, property_data=["energy_above_hull"])
 
         for e in entries:
             assert e.data.get("energy_above_hull", None) is not None
-            
+
         # Conventional structure
         formula = "BiFeO3"
         entry = mpr.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=True)[0]
 
-        Ni = entry.strget_entries_inucture
-        self.assertEqual(Ni.lattice.a, Ni.lattice.b)
-        self.assertEqual(Ni.lattice.a, Ni.lattice.c)
-        self.assertEqual(Ni.lattice.alpha, 90)
-        self.assertEqual(Ni.lattice.beta, 90)
-        self.assertEqual(Ni.lattice.gamma, 90)
-        
+        Ni = entry.structure
+        assert Ni.lattice.a == Ni.lattice.b
+        assert Ni.lattice.a == Ni.lattice.c
+        assert Ni.lattice.alpha == 90
+        assert Ni.lattice.beta == 90
+        assert Ni.lattice.gamma == 90
+
         # Ensure energy per atom is same
         primNi = mpr.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=False)[0]
-        self.assertEqual(primNi.energy_per_atom, entry.energy_per_atom)
+        assert primNi.energy_per_atom == entry.energy_per_atom
 
     def test_get_entries_in_chemsys(self, mpr):
         syms = ["Li", "Fe", "O"]
@@ -177,7 +176,6 @@ class TestMPRester:
         for e in gibbs_entries:
             assert isinstance(e, GibbsComputedStructureEntry)
 
-    @pytest.mark.skip(reason="Until SSL issue fix")
     def test_get_pourbaix_entries(self, mpr):
         # test input chemsys as a list of elements
         pbx_entries = mpr.get_pourbaix_entries(["Fe", "Cr"])
@@ -218,7 +216,6 @@ class TestMPRester:
         # so4_two_minus = pbx_entries[9]
         # self.assertAlmostEqual(so4_two_minus.energy, 0.301511, places=3)
 
-    @pytest.mark.skip(reason="Until SSL issue fix")
     def test_get_ion_entries(self, mpr):
         entries = mpr.get_entries_in_chemsys("Ti-O-H")
         pd = PhaseDiagram(entries)

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -277,6 +277,7 @@ class TestMPRester:
         dos = mpr.get_phonon_dos_by_material_id("mp-11659")
         assert isinstance(dos, PhononDos)
 
+    @pytest.mark.skip(reason="Test needs fixing with ENV variables")
     def test_get_charge_density_data(self, mpr):
         chgcar = mpr.get_charge_density_from_material_id("mp-149")
         assert isinstance(chgcar, Chgcar)

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -130,11 +130,34 @@ class TestMPRester:
 
         assert sorted_entries != entries
 
+        # Formula
         formula = "SiO2"
         entries = mpr.get_entries(formula)
 
         for e in entries:
             assert isinstance(e, ComputedEntry)
+            
+        # Property data
+        formula = "BiFeO3"
+        entries = mpr.get_entries(formula, property_data=["energy_above_hull"])
+
+        for e in entries:
+            assert e.data.get("energy_above_hull", None) is not None
+            
+        # Conventional structure
+        formula = "BiFeO3"
+        entry = mpr.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=True)[0]
+
+        Ni = entry.strget_entries_inucture
+        self.assertEqual(Ni.lattice.a, Ni.lattice.b)
+        self.assertEqual(Ni.lattice.a, Ni.lattice.c)
+        self.assertEqual(Ni.lattice.alpha, 90)
+        self.assertEqual(Ni.lattice.beta, 90)
+        self.assertEqual(Ni.lattice.gamma, 90)
+        
+        # Ensure energy per atom is same
+        primNi = mpr.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=False)[0]
+        self.assertEqual(primNi.energy_per_atom, entry.energy_per_atom)
 
     def test_get_entries_in_chemsys(self, mpr):
         syms = ["Li", "Fe", "O"]

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -9,6 +9,7 @@ from emmet.core.summary import HasProps
 from emmet.core.symmetry import CrystalSystem
 from emmet.core.tasks import TaskDoc
 from emmet.core.vasp.calc_types import CalcType
+from sympy import prime
 from mp_api.client.core.settings import MAPIClientSettings
 from mp_api.client import MPRester
 from pymatgen.analysis.magnetism import Ordering
@@ -145,18 +146,24 @@ class TestMPRester:
 
         # Conventional structure
         formula = "BiFeO3"
-        entry = mpr.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=True)[0]
+        entry = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=True)[0]
 
-        Ni = entry.structure
-        assert Ni.lattice.a == Ni.lattice.b
-        assert Ni.lattice.a == Ni.lattice.c
-        assert Ni.lattice.alpha == 90
-        assert Ni.lattice.beta == 90
-        assert Ni.lattice.gamma == 90
+        s = entry.structure
+        assert pytest.approx(s.lattice.a) == s.lattice.b
+        assert pytest.approx(s.lattice.a) != s.lattice.c
+        assert pytest.approx(s.lattice.alpha) == 90
+        assert pytest.approx(s.lattice.beta) == 90
+        assert pytest.approx(s.lattice.gamma) == 120
 
         # Ensure energy per atom is same
-        primNi = mpr.get_entry_by_material_id("mp-23", inc_structure=True, conventional_unit_cell=False)[0]
-        assert primNi.energy_per_atom == entry.energy_per_atom
+        prim = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=False)[0]
+        assert prim.energy_per_atom == entry.energy_per_atom
+        
+        s = prim.structure
+        assert pytest.approx(s.lattice.a) == s.lattice.b
+        assert pytest.approx(s.lattice.a) == s.lattice.c
+        assert pytest.approx(s.lattice.alpha) == s.lattice.beta
+        assert pytest.approx(s.lattice.alpha) == s.lattice.gamma
 
     def test_get_entries_in_chemsys(self, mpr):
         syms = ["Li", "Fe", "O"]

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -91,6 +91,7 @@ class TestMPRester:
         structs = mpr.get_structures("Mn-O", final=False)
         assert len(structs) > 0
 
+    @pytest.mark.skip(reason="Endpoint issues")
     def test_find_structure(self, mpr):
         path = os.path.join(MAPIClientSettings().TEST_FILES, "Si_mp_149.cif")
         with open(path) as file:
@@ -157,8 +158,8 @@ class TestMPRester:
 
         # Ensure energy per atom is same
         prim = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=False)[0]
-        assert prim.energy_per_atom == entry.energy_per_atom
-        
+        assert pytest.approx(prim.energy_per_atom) == entry.energy_per_atom
+
         s = prim.structure
         assert pytest.approx(s.lattice.a) == s.lattice.b
         assert pytest.approx(s.lattice.a) == s.lattice.c
@@ -276,7 +277,6 @@ class TestMPRester:
         dos = mpr.get_phonon_dos_by_material_id("mp-11659")
         assert isinstance(dos, PhononDos)
 
-    @pytest.mark.xfail(reason="SSL issue")
     def test_get_charge_density_data(self, mpr):
         chgcar = mpr.get_charge_density_from_material_id("mp-149")
         assert isinstance(chgcar, Chgcar)


### PR DESCRIPTION
This PR ensures backwards compatibility between the legacy MPRester top level methods involving getting `ComputedStructureEntry` objects. Specifically,

- MPRester.get_entries
- MPRester.get_entries_in_chemsys
- MPRester.get_entry_by_material_id

For most of the added arguments, the missing functionality is fully implemented. The two that are deprecated are `additional_criteria` and `inc_structure`. The user is warned when passing these directly. Additional warnings are included in the docstrings.