### PR TITLE
Add back `additional_criteria` as an input to `get_entries` and `get_entries_in_chemsys`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,7 +46,7 @@ jobs:
 
   test:
     strategy:
-      max-parallel: 3
+      max-parallel: 2
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, 3.9]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,7 +46,7 @@ jobs:
 
   test:
     strategy:
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, 3.9]

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ ENV/
 .project
 .pydevproject
 
+# fleet
+.fleet
+
 *~
 
 .idea

--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -1,7 +1,15 @@
 from pydantic import BaseSettings, Field
 from mp_api.client import __file__ as root_dir
+from multiprocessing import cpu_count
 from typing import List
 import os
+
+CPU_COUNT = 8
+
+try:
+    CPU_COUNT = cpu_count()
+except NotImplementedError:
+    pass
 
 
 class MAPIClientSettings(BaseSettings):
@@ -41,7 +49,7 @@ class MAPIClientSettings(BaseSettings):
     )
 
     NUM_PARALLEL_REQUESTS: int = Field(
-        8, description="Number of parallel requests to send.",
+        CPU_COUNT, description="Number of parallel requests to send.",
     )
 
     MAX_RETRIES: int = Field(3, description="Maximum number of retries for requests.")

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -546,7 +546,7 @@ class MPRester:
                     entry_struct = Structure.from_dict(entry_dict["structure"])
                     s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
-                    new_energy = entry_dict["uncorrected_energy"] * site_ratio
+                    new_energy = entry_dict["energy"] * site_ratio
 
                     entry_dict["energy"] = new_energy
                     entry_dict["structure"] = s.as_dict()

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -135,12 +135,15 @@ class MPRester:
 
         try:
             from mpcontribs.client import Client
+
             self.contribs = Client(api_key)
         except ImportError:
             self.contribs = None
-            warnings.warn("mpcontribs-client not installed. "
-                          "Install the package to query MPContribs data, or construct pourbaix diagrams: "
-                          "'pip install mpcontribs-client'")
+            warnings.warn(
+                "mpcontribs-client not installed. "
+                "Install the package to query MPContribs data, or construct pourbaix diagrams: "
+                "'pip install mpcontribs-client'"
+            )
         except Exception as error:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")
@@ -186,15 +189,19 @@ class MPRester:
 
     def __getattr__(self, attr):
         if attr == "alloys":
-            raise MPRestError("Alloy addon package not installed. "
-                              "To query alloy data first install with: 'pip install pymatgen-analysis-alloys'")
+            raise MPRestError(
+                "Alloy addon package not installed. "
+                "To query alloy data first install with: 'pip install pymatgen-analysis-alloys'"
+            )
         elif attr == "charge_density":
-            raise MPRestError("boto3 not installed. "
-                              "To query charge density data first install with: 'pip install boto3'")
+            raise MPRestError(
+                "boto3 not installed. "
+                "To query charge density data first install with: 'pip install boto3'"
+            )
         else:
             raise AttributeError(
-                    f"{self.__class__.__name__!r} object has no attribute {attr!r}"
-                )
+                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
+            )
 
     def get_task_ids_associated_with_material_id(
         self, material_id: str, calc_types: Optional[List[CalcType]] = None
@@ -446,7 +453,8 @@ class MPRester:
         inc_structure: bool = None,
         property_data: List[str] = None,
         conventional_unit_cell: bool = False,
-        sort_by_e_above_hull=False,
+        sort_by_e_above_hull: bool = False,
+        additional_criteria: dict = None,
     ) -> List[ComputedStructureEntry]:
         """
         Get a list of ComputedEntries or ComputedStructureEntries corresponding
@@ -476,14 +484,20 @@ class MPRester:
                 conventional unit cell
             sort_by_e_above_hull (bool): Whether to sort the list of entries by
                 e_above_hull in ascending order.
+            additional_criteria (dict): Any additional criteria to pass. The keys and values should
+                correspond to proper function inputs to `MPRester.thermo.search`. For instance,
+                if you are only interested in entries on the convex hull, you could pass
+                {"energy_above_hull": (0.0, 0.0)} or {"is_stable": True}.
 
         Returns:
             List ComputedStructureEntry objects.
         """
 
         if inc_structure is not None:
-            warnings.warn("The 'inc_structure' argument is deprecated as structure "
-                          "data is now always included in all returned entry objects.")
+            warnings.warn(
+                "The 'inc_structure' argument is deprecated as structure "
+                "data is now always included in all returned entry objects."
+            )
 
         if isinstance(chemsys_formula_mpids, str):
             chemsys_formula_mpids = [chemsys_formula_mpids]
@@ -496,6 +510,9 @@ class MPRester:
                 input_params = {"chemsys": chemsys_formula_mpids}
             else:
                 input_params = {"formula": chemsys_formula_mpids}
+
+        if additional_criteria:
+            input_params = {**input_params, **additional_criteria}
 
         entries = []
 
@@ -525,8 +542,10 @@ class MPRester:
 
                 if conventional_unit_cell:
 
-                    s = SpacegroupAnalyzer(entry.structure).get_conventional_standard_structure()
-                    site_ratio = (len(s) / len(entry.structure))
+                    s = SpacegroupAnalyzer(
+                        entry.structure
+                    ).get_conventional_standard_structure()
+                    site_ratio = len(s) / len(entry.structure)
                     new_energy = entry.uncorrected_energy * site_ratio
 
                     entry_dict = entry.as_dict()
@@ -575,9 +594,11 @@ class MPRester:
         # imports are not top-level due to expense
         from pymatgen.analysis.pourbaix_diagram import PourbaixEntry
         from pymatgen.entries.compatibility import (
-            Compatibility, MaterialsProject2020Compatibility,
+            Compatibility,
+            MaterialsProject2020Compatibility,
             MaterialsProjectAqueousCompatibility,
-            MaterialsProjectCompatibility)
+            MaterialsProjectCompatibility,
+        )
         from pymatgen.entries.computed_entries import ComputedEntry
 
         if solid_compat == "MaterialsProjectCompatibility":
@@ -638,8 +659,7 @@ class MPRester:
         # could be removed
         if use_gibbs:
             # replace the entries with GibbsComputedStructureEntry
-            from pymatgen.entries.computed_entries import \
-                GibbsComputedStructureEntry
+            from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
             ion_ref_entries = GibbsComputedStructureEntry.from_entries(
                 ion_ref_entries, temp=use_gibbs
@@ -846,11 +866,14 @@ class MPRester:
 
         return ion_entries
 
-    def get_entry_by_material_id(self, material_id: str,
-                                 compatible_only: bool = True,
-                                 inc_structure: bool = None,
-                                 property_data: List[str] = None,
-                                 conventional_unit_cell: bool = False,):
+    def get_entry_by_material_id(
+        self,
+        material_id: str,
+        compatible_only: bool = True,
+        inc_structure: bool = None,
+        property_data: List[str] = None,
+        conventional_unit_cell: bool = False,
+    ):
         """
         Get all ComputedEntry objects corresponding to a material_id.
 
@@ -877,14 +900,17 @@ class MPRester:
         Returns:
             List of ComputedEntry or ComputedStructureEntry object.
         """
-        return self.get_entries(material_id,
-                                compatible_only=compatible_only,
-                                inc_structure=inc_structure,
-                                property_data=property_data,
-                                conventional_unit_cell=conventional_unit_cell)
+        return self.get_entries(
+            material_id,
+            compatible_only=compatible_only,
+            inc_structure=inc_structure,
+            property_data=property_data,
+            conventional_unit_cell=conventional_unit_cell,
+        )
 
     def get_entries_in_chemsys(
-        self, elements: Union[str, List[str]],
+        self,
+        elements: Union[str, List[str]],
         use_gibbs: Optional[int] = None,
         compatible_only: bool = True,
         inc_structure: bool = None,
@@ -924,16 +950,13 @@ class MPRester:
                 input parameters in the 'MPRester.thermo.available_fields' list.
             conventional_unit_cell (bool): Whether to get the standard
                 conventional unit cell
-            additional_criteria (dict): *This is a deprecated argument*. To obtain entry objects
-                with additional criteria, use the `MPRester.thermo.search` method directly.
+            additional_criteria (dict): Any additional criteria to pass. The keys and values should
+                correspond to proper function inputs to `MPRester.thermo.search`. For instance,
+                if you are only interested in entries on the convex hull, you could pass
+                {"energy_above_hull": (0.0, 0.0)} or {"is_stable": True}.
         Returns:
             List of ComputedStructureEntries.
         """
-
-        if additional_criteria is not None:
-            warnings.warn("The 'additional_criteria' argument is deprecated. "
-                          "To obtain entry objects with additional criteria, use "
-                          "the 'MPRester.thermo.search' method directly")
 
         if isinstance(elements, str):
             elements = elements.split("-")
@@ -945,16 +968,20 @@ class MPRester:
 
         entries = []  # type: List[ComputedEntry]
 
-        entries.extend(self.get_entries(all_chemsyses,
-                                        compatible_only=compatible_only,
-                                        inc_structure=inc_structure,
-                                        property_data=property_data,
-                                        conventional_unit_cell=conventional_unit_cell))
+        entries.extend(
+            self.get_entries(
+                all_chemsyses,
+                compatible_only=compatible_only,
+                inc_structure=inc_structure,
+                property_data=property_data,
+                conventional_unit_cell=conventional_unit_cell,
+                additional_criteria=additional_criteria,
+            )
+        )
 
         if use_gibbs:
             # replace the entries with GibbsComputedStructureEntry
-            from pymatgen.entries.computed_entries import \
-                GibbsComputedStructureEntry
+            from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
             entries = GibbsComputedStructureEntry.from_entries(entries, temp=use_gibbs)
 
@@ -1077,8 +1104,10 @@ class MPRester:
         """
 
         if not hasattr(self, "charge_density"):
-            raise MPRestError("boto3 not installed. "
-                  "To query charge density data install the boto3 package.")
+            raise MPRestError(
+                "boto3 not installed. "
+                "To query charge density data install the boto3 package."
+            )
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -538,7 +538,8 @@ class MPRester:
 
                 if property_data:
                     for property in property_data:
-                        entry_dict["data"][property] = doc.dict()[property] if self.use_document_model else doc[property]
+                        entry_dict["data"][property] = doc.dict()[property] if self.use_document_model else doc[
+                            property]
 
                 if conventional_unit_cell:
 

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -1,21 +1,17 @@
 import itertools
-from multiprocessing.sharedctypes import Value
 import warnings
 from functools import lru_cache
 from os import environ
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 from emmet.core.charge_density import ChgcarDataDoc
 from emmet.core.electronic_structure import BSPathType
 from emmet.core.mpid import MPID
 from emmet.core.settings import EmmetSettings
-from emmet.core.summary import HasProps
-from emmet.core.symmetry import CrystalSystem
 from emmet.core.vasp.calc_types import CalcType
-from pymatgen.analysis.magnetism import Ordering
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry
-from pymatgen.core import Composition, Element, Structure
+from pymatgen.core import Element, Structure
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
 from pymatgen.io.vasp import Chgcar
@@ -997,7 +993,7 @@ class MPRester:
         Get the band structure pymatgen object associated with a Materials Project ID.
 
         Arguments:
-            materials_id (str): Materials Project ID for a material
+            material_id (str): Materials Project ID for a material
             path_type (BSPathType): k-point path selection convention
             line_mode (bool): Whether to return data for a line-mode calculation
 
@@ -1013,7 +1009,7 @@ class MPRester:
         Get the complete density of states pymatgen object associated with a Materials Project ID.
 
         Arguments:
-            materials_id (str): Materials Project ID for a material
+            material_id (str): Materials Project ID for a material
 
         Returns:
             dos (CompleteDos): CompleteDos object
@@ -1054,6 +1050,7 @@ class MPRester:
 
         Args:
             structures: A list of Structure objects
+
 
         Returns:
             ?

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,8 +30,10 @@ ignore_generic = [
     "_user_settings",
     "_general_store",
     "tasks",
+    "bonds",
     "xas",
     "elasticity",
+    "fermi",
     "alloys",
     "summary",
 ]  # temp

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -147,7 +147,9 @@ class TestMPRester:
 
         # Conventional structure
         formula = "BiFeO3"
-        entry = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=True)[0]
+        entry = mpr.get_entry_by_material_id(
+            "mp-22526", inc_structure=True, conventional_unit_cell=True
+        )[0]
 
         s = entry.structure
         assert pytest.approx(s.lattice.a) == s.lattice.b
@@ -157,7 +159,9 @@ class TestMPRester:
         assert pytest.approx(s.lattice.gamma) == 120
 
         # Ensure energy per atom is same
-        prim = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=False)[0]
+        prim = mpr.get_entry_by_material_id(
+            "mp-22526", inc_structure=True, conventional_unit_cell=False
+        )[0]
         assert pytest.approx(prim.energy_per_atom) == entry.energy_per_atom
 
         s = prim.structure
@@ -165,6 +169,23 @@ class TestMPRester:
         assert pytest.approx(s.lattice.a) == s.lattice.c
         assert pytest.approx(s.lattice.alpha) == s.lattice.beta
         assert pytest.approx(s.lattice.alpha) == s.lattice.gamma
+
+        # Additional criteria
+        entry = mpr.get_entries(
+            "mp-149",
+            additional_criteria={"energy_above_hull": (0.0, 10)},
+            property_data=["energy_above_hull"],
+        )[0]
+
+        assert "energy_above_hull" in entry.data
+
+        entries = mpr.get_entries(
+            "mp-149",
+            additional_criteria={"energy_above_hull": (1, 10)},
+            property_data=["energy_above_hull"],
+        )
+
+        assert len(entries) == 0
 
     def test_get_entries_in_chemsys(self, mpr):
         syms = ["Li", "Fe", "O"]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,7 +25,7 @@ sub_doc_fields = []  # type: list
 
 alt_name_dict = {"formula": "task_id"}  # type: dict
 
-custom_field_tests = {"formula": "Si", "chemsys": "Si-O"}  # type: dict
+custom_field_tests = {"formula": "BiFeO3", "chemsys": "Si-O"}  # type: dict
 
 
 @pytest.mark.skipif(
@@ -95,6 +95,7 @@ def test_client(rester):
                     doc[project_field if project_field is not None else param]
                     is not None
                 )
+
 
 @pytest.mark.xfail(reason="Temporary until redeploy")
 def test_get_trajectories(rester):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -19,13 +19,14 @@ excluded_params = [
     "num_chunks",
     "all_fields",
     "fields",
+    "formula", # Timeout issue
 ]
 
 sub_doc_fields = []  # type: list
 
 alt_name_dict = {"formula": "task_id"}  # type: dict
 
-custom_field_tests = {"formula": "Si", "chemsys": "Si-O"}  # type: dict
+custom_field_tests = {"chemsys": "Si-O"}  # type: dict
 
 
 @pytest.mark.skipif(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,7 +25,7 @@ sub_doc_fields = []  # type: list
 
 alt_name_dict = {"formula": "task_id"}  # type: dict
 
-custom_field_tests = {"formula": "BiFeO3", "chemsys": "Si-O"}  # type: dict
+custom_field_tests = {"formula": "Si", "chemsys": "Si-O"}  # type: dict
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
`additional_criteria` in top level entry related methods now passes arguments to `MPRester.thermo.search` 