### PR TITLE
Insert missing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     extras_require={
         "all": [
-            "emmet-core[all]>=0.36.4"
+            "emmet-core[all]>=0.36.4",
             "custodian",
             "mpcontribs-client",
             "boto3"


### PR DESCRIPTION
There is a missing comma on line 36 of `setup.py` that causes `"emmet-core[all]>=0.36.4"` and `"custodian"` to be interpreted as one string.

This then corrupts the `poetry.lock` that gets generated for projects that depend on `mp-api`, e.g.
```toml
[[package]]
name = "mp-api"
version = "0.29.2"
description = "API Server for the Materials Project"
category = "main"
optional = false
python-versions = ">=3.8"

[package.dependencies]
emmet-core = ">=0.36.4"
monty = ">=2021.3.12"
msgpack = "*"
pymatgen = ">=2022.3.7"
requests = ">=2.23.0"
typing-extensions = ">=3.7.4.1"

[package.extras]
all = ["boto3", "emmet-core[all] (>=0.36.4custodian)", "mpcontribs-client"]
```
yields
```
[...]
Installing dependencies from lock file

Could not parse version constraint: >=0.36.4custodian
```