### PR TITLE
Fix robocrys search pagination

### DIFF
--- a/mp_api/client/routes/robocrys.py
+++ b/mp_api/client/routes/robocrys.py
@@ -49,7 +49,8 @@ class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
             criteria={"keywords": keyword_string, "_limit": chunk_size},
             suburl="text_search",
             use_document_model=True,
-            chunk_size=100,
+            chunk_size=chunk_size,
+            num_chunks=num_chunks,
         ).get("data", None)
 
         if robocrys_docs is None:


### PR DESCRIPTION
Ensure `num_chunks` and `chunk_size` work properly with robocrys search method.