### PR TITLE
Accept `list[str]` for `thermo_types` in `ThermoRester.search()`

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -457,6 +457,9 @@ class MPRester:
         Get a list of ComputedEntries or ComputedStructureEntries corresponding
         to a chemical system or formula.
 
+        Note that by default this returns mixed GGA/GGA+U entries. For others,
+        pass GGA/GGA+U/R2SCAN, or R2SCAN as thermo_types in additional_criteria.
+
         Args:
             chemsys_formula_mpids (str, List[str]): A chemical system, list of chemical systems
                 (e.g., Li-Fe-O, Si-*, [Si-O, Li-Fe-P]), formula, list of formulas
@@ -889,6 +892,10 @@ class MPRester:
         entries in the Li-Fe-O chemical system, i.e., all LixOy,
         FexOy, LixFey, LixFeyOz, Li, Fe and O phases. Extremely useful for
         creating phase diagrams of entire chemical systems.
+
+        Note that by default this returns mixed GGA/GGA+U entries. For others,
+        pass GGA/GGA+U/R2SCAN, or R2SCAN as thermo_types in additional_criteria.
+
         Args:
             elements (str or [str]): Chemical system string comprising element
                 symbols separated by dashes, e.g., "Li-Fe-O" or List of element
@@ -918,7 +925,8 @@ class MPRester:
             additional_criteria (dict): Any additional criteria to pass. The keys and values should
                 correspond to proper function inputs to `MPRester.thermo.search`. For instance,
                 if you are only interested in entries on the convex hull, you could pass
-                {"energy_above_hull": (0.0, 0.0)} or {"is_stable": True}.
+                {"energy_above_hull": (0.0, 0.0)} or {"is_stable": True}, or if you are only interested
+                in entry data 
         Returns:
             List of ComputedStructureEntries.
         """

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -106,9 +106,9 @@ class ThermoRester(BaseRester[ThermoDoc]):
         if thermo_types:
             t_types = {t if isinstance(t, str) else t.value for t in thermo_types}
             valid_types = {*map(str, ThermoType.__members__.values())}
-            if t_types - valid_types:
+            if invalid_types := t_types - valid_types:
                 raise ValueError(
-                    f"Invalid thermo type(s) passed: {t_types}, valid types are: {valid_types}"
+                    f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
                 )
             query_params.update({"thermo_types": ",".join(t_types)})
 

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -1,10 +1,12 @@
 import warnings
 from collections import defaultdict
-from typing import Optional, List, Tuple, Union
-from mp_api.client.core import BaseRester
-from mp_api.client.core.utils import validate_ids
+from typing import List, Optional, Tuple, Union
+
 from emmet.core.thermo import ThermoDoc, ThermoType
 from pymatgen.analysis.phase_diagram import PhaseDiagram
+
+from mp_api.client.core import BaseRester
+from mp_api.client.core.utils import validate_ids
 
 
 class ThermoRester(BaseRester[ThermoDoc]):
@@ -39,7 +41,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
         material_ids: Optional[List[str]] = None,
         num_elements: Optional[Tuple[int, int]] = None,
         thermo_ids: Optional[List[str]] = None,
-        thermo_types: Optional[List[ThermoType]] = [ThermoType.GGA_GGA_U],
+        thermo_types: Optional[List[Union[ThermoType, str]]] = [ThermoType.GGA_GGA_U],
         total_energy: Optional[Tuple[float, float]] = None,
         uncorrected_energy: Optional[Tuple[float, float]] = None,
         sort_fields: Optional[List[str]] = None,
@@ -102,9 +104,12 @@ class ThermoRester(BaseRester[ThermoDoc]):
             query_params.update({"thermo_ids": ",".join(validate_ids(thermo_ids))})
 
         if thermo_types:
-            query_params.update(
-                {"thermo_types": ",".join([t.value for t in thermo_types])}
-            )
+            t_types = [t if isinstance(t, str) else t.value for t in thermo_types]
+            if not all(hasattr(ThermoType, t) for t in t_types):
+                raise ValueError(
+                    f"Invalid thermo type(s) passed: {t_types}, valid types are: {list(ThermoType.__members__)}"
+                )
+            query_params.update({"thermo_types": ",".join(t_types)})
 
         if num_elements:
             if isinstance(num_elements, int):

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -104,10 +104,11 @@ class ThermoRester(BaseRester[ThermoDoc]):
             query_params.update({"thermo_ids": ",".join(validate_ids(thermo_ids))})
 
         if thermo_types:
-            t_types = [t if isinstance(t, str) else t.value for t in thermo_types]
-            if not all(hasattr(ThermoType, t) for t in t_types):
+            t_types = {t if isinstance(t, str) else t.value for t in thermo_types}
+            valid_types = {*map(str, ThermoType.__members__.values())}
+            if t_types - valid_types:
                 raise ValueError(
-                    f"Invalid thermo type(s) passed: {t_types}, valid types are: {list(ThermoType.__members__)}"
+                    f"Invalid thermo type(s) passed: {t_types}, valid types are: {valid_types}"
                 )
             query_params.update({"thermo_types": ",".join(t_types)})
 


### PR DESCRIPTION
Let me know if I should add a test for this.

Also, I just used `str` in the type hint as using `Literal` would break single source of truth for accepted values. But happy to change that if you prefer `Literal`.