### PR TITLE
Fix `el_refs` dict keys in `PhaseDiagram` objects

### DIFF
--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -174,9 +174,9 @@ class ThermoRester(BaseRester[ThermoDoc]):
             use_document_model=False,
             num_chunks=1,
             chunk_size=1,
-        ).get("data")
+        ).get("data", [{}])
 
-        pd = response[0]["phase_diagram"]
+        pd = response[0].get("phase_diagram", None)
 
         # Ensure el_ref keys are Element objects for PDPlotter.
         # This should be fixed in pymatgen

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -5,6 +5,7 @@ from mp_api.client.core import BaseRester
 from mp_api.client.core.utils import validate_ids
 from emmet.core.thermo import ThermoDoc, ThermoType
 from pymatgen.analysis.phase_diagram import PhaseDiagram
+from pymatgen.core import Element
 
 
 class ThermoRester(BaseRester[ThermoDoc]):
@@ -175,4 +176,16 @@ class ThermoRester(BaseRester[ThermoDoc]):
             chunk_size=1,
         ).get("data")
 
-        return response[0]["phase_diagram"]  # type: ignore
+        pd = response[0]["phase_diagram"]
+
+        # Ensure el_ref keys are Element objects for PDPlotter.
+        # This should be fixed in pymatgen
+        if pd:
+            for key, entry in list(pd.el_refs.items()):
+                if not isinstance(key, str):
+                    break
+                    
+            pd.el_refs[Element(str(key))] = entry
+            pd.el_refs.pop(key)
+
+        return pd  # type: ignore

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -184,8 +184,8 @@ class ThermoRester(BaseRester[ThermoDoc]):
             for key, entry in list(pd.el_refs.items()):
                 if not isinstance(key, str):
                     break
-                    
-            pd.el_refs[Element(str(key))] = entry
-            pd.el_refs.pop(key)
+
+                pd.el_refs[Element(str(key))] = entry
+                pd.el_refs.pop(key)
 
         return pd  # type: ignore


### PR DESCRIPTION
Ensure keys for `el_refs` attribute of `PhaseDiagram` objects are returned as `Element` objects instead of strings. This ensures `PDPlotter` can be called on them. This is will fixed in pymatgen shortly.