### PR TITLE
Initial MPcules Summary RESTer

### DIFF
--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -59,9 +59,7 @@ class MAPIClientSettings(BaseSettings):
         description="Number of parallel requests to send.",
     )
 
-    MAX_RETRIES: int = Field(
-        _MAX_RETRIES, description="Maximum number of retries for requests."
-    )
+    MAX_RETRIES: int = Field(_MAX_RETRIES, description="Maximum number of retries for requests.")
 
     MUTE_PROGRESS_BARS: bool = Field(
         _MUTE_PROGRESS_BAR,

--- a/mp_api/client/core/utils.py
+++ b/mp_api/client/core/utils.py
@@ -45,9 +45,7 @@ def api_sanitize(
     """
 
     models = [
-        model
-        for model in get_flat_models_from_model(pydantic_model)
-        if issubclass(model, BaseModel)
+        model for model in get_flat_models_from_model(pydantic_model) if issubclass(model, BaseModel)
     ]  # type: List[Type[BaseModel]]
 
     fields_to_leave = fields_to_leave or []
@@ -100,9 +98,7 @@ def allow_msonable_dict(monty_cls: Type[MSONable]):
                 errors.append("@class")
 
             if len(errors) > 0:
-                raise ValueError(
-                    "Missing Monty seriailzation fields in dictionary: {errors}"
-                )
+                raise ValueError("Missing Monty seriailzation fields in dictionary: {errors}")
 
             return v
         else:

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -74,6 +74,7 @@ class MPRester:
     provenance: ProvenanceRester
     bonds: BondsRester
     alloys: AlloysRester
+    mpcules_summary: MPculesSummaryRester
     _user_settings: UserSettingsRester
     _general_store: GeneralStoreRester
 

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -133,7 +133,9 @@ class MPRester:
         self.endpoint = endpoint
         self.headers = headers or {}
         self.session = session or BaseRester._create_session(
-            api_key=self.api_key, include_user_agent=include_user_agent, headers=self.headers
+            api_key=self.api_key,
+            include_user_agent=include_user_agent,
+            headers=self.headers,
         )
         self.use_document_model = use_document_model
         self.monty_decode = monty_decode
@@ -162,7 +164,6 @@ class MPRester:
             self.endpoint += "/"
 
         for cls in BaseRester.__subclasses__():
-
             rester = cls(
                 api_key=api_key,
                 endpoint=endpoint,
@@ -506,7 +507,6 @@ class MPRester:
         try:
             input_params = {"material_ids": validate_ids(chemsys_formula_mpids)}
         except ValueError:
-
             if any("-" in entry for entry in chemsys_formula_mpids):
                 input_params = {"chemsys": chemsys_formula_mpids}
             else:
@@ -548,7 +548,6 @@ class MPRester:
                         )
 
                 if conventional_unit_cell:
-
                     entry_struct = Structure.from_dict(entry_dict["structure"])
                     s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
@@ -604,7 +603,6 @@ class MPRester:
             MaterialsProjectAqueousCompatibility,
             MaterialsProjectCompatibility,
         )
-        from pymatgen.entries.computed_entries import ComputedEntry
 
         if solid_compat == "MaterialsProjectCompatibility":
             solid_compat = MaterialsProjectCompatibility()
@@ -711,7 +709,9 @@ class MPRester:
                 compounds and aqueous species, Wiley, New York (1978)'}}
         """
         return self.contribs.query_contributions(
-            query={"project": "ion_ref_data"}, fields=["identifier", "formula", "data"], paginate=True
+            query={"project": "ion_ref_data"},
+            fields=["identifier", "formula", "data"],
+            paginate=True,
         ).get("data")
 
     def get_ion_reference_data_for_chemsys(self, chemsys: Union[str, List]) -> List[Dict]:
@@ -1122,9 +1122,9 @@ class MPRester:
 
         meta = {}
         for doc in self.materials.search(
-            task_ids=material_ids, fields=["calc_types", "deprecated_tasks", "material_id"]
+            task_ids=material_ids,
+            fields=["calc_types", "deprecated_tasks", "material_id"],
         ):
-
             for task_id, calc_type in doc.calc_types.items():
                 if calc_types and calc_type not in calc_types:
                     continue

--- a/mp_api/client/routes/__init__.py
+++ b/mp_api/client/routes/__init__.py
@@ -30,7 +30,7 @@ from ._user_settings import UserSettingsRester
 from ._general_store import GeneralStoreRester
 from .bonds import BondsRester
 from .robocrys import RobocrysRester
-from mp_api.routes.mpcules.summary import MPculesSummaryRester
+from mp_api.client.routes.mpcules.summary import MPculesSummaryRester
 
 try:
     from .alloys import AlloysRester

--- a/mp_api/client/routes/__init__.py
+++ b/mp_api/client/routes/__init__.py
@@ -30,6 +30,7 @@ from ._user_settings import UserSettingsRester
 from ._general_store import GeneralStoreRester
 from .bonds import BondsRester
 from .robocrys import RobocrysRester
+from mp_api.routes.mpcules.summary import MPculesSummaryRester
 
 try:
     from .alloys import AlloysRester

--- a/mp_api/client/routes/_general_store.py
+++ b/mp_api/client/routes/_general_store.py
@@ -5,7 +5,6 @@ from emmet.core._general_store import GeneralStoreDoc
 
 
 class GeneralStoreRester(BaseRester[GeneralStoreDoc]):  # pragma: no cover
-
     suffix = "_general_store"
     document_model = GeneralStoreDoc  # type: ignore
     primary_key = "submission_id"
@@ -24,9 +23,7 @@ class GeneralStoreRester(BaseRester[GeneralStoreDoc]):  # pragma: no cover
         Raises:
             MPRestError
         """
-        return self._post_resource(
-            body=meta, params={"kind": kind, "markdown": markdown}
-        ).get("data")
+        return self._post_resource(body=meta, params={"kind": kind, "markdown": markdown}).get("data")
 
     def get_items(self, kind):  # pragma: no cover
         """

--- a/mp_api/client/routes/_user_settings.py
+++ b/mp_api/client/routes/_user_settings.py
@@ -3,7 +3,6 @@ from mp_api.client.core import BaseRester
 
 
 class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
-
     suffix = "_user_settings"
     document_model = UserSettingsDoc  # type: ignore
     primary_key = "consumer_id"
@@ -21,9 +20,7 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
         Raises:
             MPRestError
         """
-        return self._post_resource(
-            body=settings, params={"consumer_id": consumer_id}
-        ).get("data")
+        return self._post_resource(body=settings, params={"consumer_id": consumer_id}).get("data")
 
     def get_user_settings(self, consumer_id):  # pragma: no cover
         """

--- a/mp_api/client/routes/alloys.py
+++ b/mp_api/client/routes/alloys.py
@@ -7,7 +7,6 @@ from emmet.core.alloys import AlloyPairDoc
 
 
 class AlloysRester(BaseRester[AlloyPairDoc]):
-
     suffix = "alloys"
     document_model = AlloyPairDoc  # type: ignore
     primary_key = "pair_id"

--- a/mp_api/client/routes/bonds.py
+++ b/mp_api/client/routes/bonds.py
@@ -9,7 +9,6 @@ import warnings
 
 
 class BondsRester(BaseRester[BondingDoc]):
-
     suffix = "bonds"
     document_model = BondingDoc  # type: ignore
     primary_key = "material_id"
@@ -102,25 +101,13 @@ class BondsRester(BaseRester[BondingDoc]):
             query_params.update({"coordination_envs": ",".join(coordination_envs)})
 
         if coordination_envs_anonymous is not None:
-            query_params.update(
-                {"coordination_envs_anonymous": ",".join(coordination_envs_anonymous)}
-            )
+            query_params.update({"coordination_envs_anonymous": ",".join(coordination_envs_anonymous)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/charge_density.py
+++ b/mp_api/client/routes/charge_density.py
@@ -16,7 +16,6 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
-
     suffix = "charge_density"
     primary_key = "fs_id"
     document_model = ChgcarDataDoc  # type: ignore
@@ -50,7 +49,11 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
         return num_downloads
 
     def search(  # type: ignore
-        self, task_ids: Optional[List[str]] = None, num_chunks: Optional[int] = 1, chunk_size: int = 10, **kwargs
+        self,
+        task_ids: Optional[List[str]] = None,
+        num_chunks: Optional[int] = 1,
+        chunk_size: int = 10,
+        **kwargs,
     ) -> Union[List[ChgcarDataDoc], List[Dict]]:  # type: ignore
         """
         A search method to find what charge densities are available via this API.
@@ -80,13 +83,11 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
         url_doc = self.get_data_by_id(fs_id)
 
         if url_doc:
-
             # The check below is performed to see if the client is being
             # used by our internal AWS deployment. If it is, we pull charge
             # density data from a private S3 bucket. Else, we pull data
             # from public MinIO buckets.
             if environ.get("AWS_EXECUTION_ENV", None) == "AWS_ECS_FARGATE":
-
                 if self.boto_resource is None:
                     self.boto_resource = self._get_s3_resource(use_minio=False, unsigned=False)
 
@@ -118,7 +119,6 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
             return None
 
     def _extract_s3_url_info(self, url_doc, use_minio: bool = True):
-
         if use_minio:
             url_list = url_doc.url.split("/")
             bucket = url_list[3]
@@ -131,7 +131,6 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
         return (bucket, obj_prefix)
 
     def _get_s3_resource(self, use_minio: bool = True, unsigned: bool = True):
-
         resource = boto3.resource(
             "s3",
             endpoint_url="https://minio.materialsproject.org" if use_minio else None,

--- a/mp_api/client/routes/dielectric.py
+++ b/mp_api/client/routes/dielectric.py
@@ -9,7 +9,6 @@ import warnings
 
 
 class DielectricRester(BaseRester[DielectricDoc]):
-
     suffix = "dielectric"
     document_model = DielectricDoc  # type: ignore
     primary_key = "material_id"
@@ -87,20 +86,10 @@ class DielectricRester(BaseRester[DielectricDoc]):
             query_params.update({"n_min": n[0], "n_max": n[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/doi.py
+++ b/mp_api/client/routes/doi.py
@@ -3,7 +3,6 @@ from emmet.core.dois import DOIDoc
 
 
 class DOIRester(BaseRester[DOIDoc]):
-
     suffix = "doi"
     document_model = DOIDoc  # type: ignore
     primary_key = "task_id"

--- a/mp_api/client/routes/elasticity.py
+++ b/mp_api/client/routes/elasticity.py
@@ -8,7 +8,6 @@ import warnings
 
 
 class ElasticityRester(BaseRester[ElasticityDoc]):
-
     suffix = "elasticity"
     document_model = ElasticityDoc  # type: ignore
     primary_key = "task_id"
@@ -102,25 +101,13 @@ class ElasticityRester(BaseRester[ElasticityDoc]):
             )
 
         if poisson_ratio:
-            query_params.update(
-                {"poisson_min": poisson_ratio[0], "poisson_max": poisson_ratio[1]}
-            )
+            query_params.update({"poisson_min": poisson_ratio[0], "poisson_max": poisson_ratio[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/electrodes.py
+++ b/mp_api/client/routes/electrodes.py
@@ -9,7 +9,6 @@ from pymatgen.core.periodic_table import Element
 
 
 class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
-
     suffix = "insertion_electrodes"
     document_model = InsertionElectrodeDoc  # type: ignore
     primary_key = "battery_id"
@@ -117,9 +116,7 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
             if isinstance(working_ion, str) or isinstance(working_ion, Element):
                 working_ion = [working_ion]  # type: ignore
 
-            query_params.update(
-                {"working_ion": ",".join([str(ele) for ele in working_ion])}  # type: ignore
-            )
+            query_params.update({"working_ion": ",".join([str(ele) for ele in working_ion])})  # type: ignore
 
         if formula:
             if isinstance(formula, str):
@@ -133,17 +130,13 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if exclude_elements:
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
         for param, value in locals().items():
             if (
@@ -158,16 +151,10 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
                 and value
             ):
                 if isinstance(value, tuple):
-                    query_params.update(
-                        {f"{param}_min": value[0], f"{param}_max": value[1]}
-                    )
+                    query_params.update({f"{param}_min": value[0], f"{param}_max": value[1]})
                 else:
                     query_params.update({param: value})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(**query_params)

--- a/mp_api/client/routes/electronic_structure.py
+++ b/mp_api/client/routes/electronic_structure.py
@@ -20,7 +20,6 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
-
     suffix = "electronic_structure"
     document_model = ElectronicStructureDoc  # type: ignore
     primary_key = "material_id"
@@ -115,9 +114,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if band_gap:
-            query_params.update(
-                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
-            )
+            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -128,9 +125,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if is_gap_direct is not None:
             query_params.update({"is_gap_direct": is_gap_direct})
@@ -139,15 +134,9 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"is_metal": is_metal})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -159,7 +148,6 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
 
 
 class BandStructureRester(BaseRester):
-
     suffix = "electronic_structure/bandstructure"
     document_model = ElectronicStructureDoc  # type: ignore
 
@@ -217,9 +205,7 @@ class BandStructureRester(BaseRester):
         query_params["path_type"] = path_type.value
 
         if band_gap:
-            query_params.update(
-                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
-            )
+            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -234,15 +220,9 @@ class BandStructureRester(BaseRester):
             query_params.update({"is_metal": is_metal})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -294,46 +274,32 @@ class BandStructureRester(BaseRester):
             bandstructure (Union[BandStructure, BandStructureSymmLine]): BandStructure or BandStructureSymmLine object
         """
 
-        es_rester = ElectronicStructureRester(
-            endpoint=self.base_endpoint, api_key=self.api_key
-        )
+        es_rester = ElectronicStructureRester(endpoint=self.base_endpoint, api_key=self.api_key)
 
         if line_mode:
-            bs_data = es_rester.get_data_by_id(
-                document_id=material_id, fields=["bandstructure"]
-            ).bandstructure
+            bs_data = es_rester.get_data_by_id(document_id=material_id, fields=["bandstructure"]).bandstructure
 
             if bs_data is None:
-                raise MPRestError(
-                    f"No {path_type.value} band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No {path_type.value} band structure data found for {material_id}")
             else:
                 bs_data = bs_data.dict()
 
             if bs_data.get(path_type.value, None):
                 bs_task_id = bs_data[path_type.value]["task_id"]
             else:
-                raise MPRestError(
-                    f"No {path_type.value} band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No {path_type.value} band structure data found for {material_id}")
         else:
-            bs_data = es_rester.get_data_by_id(
-                document_id=material_id, fields=["dos"]
-            ).dos
+            bs_data = es_rester.get_data_by_id(document_id=material_id, fields=["dos"]).dos
 
             if bs_data is None:
-                raise MPRestError(
-                    f"No uniform band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No uniform band structure data found for {material_id}")
             else:
                 bs_data = bs_data.dict()
 
             if bs_data.get("total", None):
                 bs_task_id = bs_data["total"]["1"]["task_id"]
             else:
-                raise MPRestError(
-                    f"No uniform band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No uniform band structure data found for {material_id}")
 
         bs_obj = self.get_bandstructure_from_task_id(bs_task_id)
 
@@ -349,7 +315,6 @@ class BandStructureRester(BaseRester):
 
 
 class DosRester(BaseRester):
-
     suffix = "electronic_structure/dos"
     document_model = ElectronicStructureDoc  # type: ignore
 
@@ -416,9 +381,7 @@ class DosRester(BaseRester):
             query_params["orbital"] = orbital.value
 
         if band_gap:
-            query_params.update(
-                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
-            )
+            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -427,15 +390,9 @@ class DosRester(BaseRester):
             query_params.update({"magnetic_ordering": magnetic_ordering.value})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -480,13 +437,9 @@ class DosRester(BaseRester):
             dos (CompleteDos): CompleteDos object
         """
 
-        es_rester = ElectronicStructureRester(
-            endpoint=self.base_endpoint, api_key=self.api_key
-        )
+        es_rester = ElectronicStructureRester(endpoint=self.base_endpoint, api_key=self.api_key)
 
-        dos_data = es_rester.get_data_by_id(
-            document_id=material_id, fields=["dos"]
-        ).dict()
+        dos_data = es_rester.get_data_by_id(document_id=material_id, fields=["dos"]).dict()
 
         if dos_data["dos"]:
             dos_task_id = dos_data["dos"]["total"]["1"]["task_id"]

--- a/mp_api/client/routes/eos.py
+++ b/mp_api/client/routes/eos.py
@@ -8,7 +8,6 @@ import warnings
 
 
 class EOSRester(BaseRester[EOSDoc]):
-
     suffix = "eos"
     document_model = EOSDoc  # type: ignore
     primary_key = "task_id"
@@ -19,8 +18,7 @@ class EOSRester(BaseRester[EOSDoc]):
         """
 
         warnings.warn(
-            "MPRester.eos.search_eos_docs is deprecated. "
-            "Please use MPRester.eos.search instead.",
+            "MPRester.eos.search_eos_docs is deprecated. " "Please use MPRester.eos.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -60,25 +58,13 @@ class EOSRester(BaseRester[EOSDoc]):
             query_params.update({"volumes_min": volumes[0], "volumes_max": volumes[1]})
 
         if energies:
-            query_params.update(
-                {"energies_min": energies[0], "energies_max": energies[1]}
-            )
+            query_params.update({"energies_min": energies[0], "energies_max": energies[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/fermi.py
+++ b/mp_api/client/routes/fermi.py
@@ -4,7 +4,6 @@ from typing import Optional, List
 
 
 class FermiRester(BaseRester[FermiDoc]):
-
     suffix = "fermi"
     document_model = FermiDoc  # type: ignore
     primary_key = "task_id"

--- a/mp_api/client/routes/grain_boundary.py
+++ b/mp_api/client/routes/grain_boundary.py
@@ -10,7 +10,6 @@ import warnings
 
 
 class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
-
     suffix = "grain_boundary"
     document_model = GrainBoundaryDoc  # type: ignore
     primary_key = "task_id"
@@ -82,14 +81,10 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             query_params.update({"gb_plane": ",".join([str(n) for n in gb_plane])})
 
         if gb_energy:
-            query_params.update(
-                {"gb_energy_min": gb_energy[0], "gb_energy_max": gb_energy[1]}
-            )
+            query_params.update({"gb_energy_min": gb_energy[0], "gb_energy_max": gb_energy[1]})
 
         if separation_energy:
-            query_params.update(
-                {"w_sep_min": separation_energy[0], "w_sep_max": separation_energy[1]}
-            )
+            query_params.update({"w_sep_min": separation_energy[0], "w_sep_max": separation_energy[1]})
 
         if rotation_angle:
             query_params.update(
@@ -100,9 +95,7 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             )
 
         if rotation_axis:
-            query_params.update(
-                {"rotation_axis": ",".join([str(n) for n in rotation_axis])}
-            )
+            query_params.update({"rotation_axis": ",".join([str(n) for n in rotation_axis])})
 
         if sigma:
             query_params.update({"sigma": sigma})
@@ -117,20 +110,10 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             query_params.update({"pretty_formula": pretty_formula})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/magnetism.py
+++ b/mp_api/client/routes/magnetism.py
@@ -11,7 +11,6 @@ import warnings
 
 
 class MagnetismRester(BaseRester[MagnetismDoc]):
-
     suffix = "magnetism"
     document_model = MagnetismDoc  # type: ignore
     primary_key = "material_id"
@@ -22,8 +21,7 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         """
 
         warnings.warn(
-            "MPRester.magnetism.search_magnetism_docs is deprecated. "
-            "Please use MPRester.magnetism.search instead.",
+            "MPRester.magnetism.search_magnetism_docs is deprecated. " "Please use MPRester.magnetism.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -38,9 +36,7 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         ordering: Optional[Ordering] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[
-            Tuple[float, float]
-        ] = None,
+        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
         sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
         chunk_size: int = 1000,
@@ -92,24 +88,16 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         if total_magnetization_normalized_vol:
             query_params.update(
                 {
-                    "total_magnetization_normalized_vol_min": total_magnetization_normalized_vol[
-                        0
-                    ],
-                    "total_magnetization_normalized_vol_max": total_magnetization_normalized_vol[
-                        1
-                    ],
+                    "total_magnetization_normalized_vol_min": total_magnetization_normalized_vol[0],
+                    "total_magnetization_normalized_vol_max": total_magnetization_normalized_vol[1],
                 }
             )
 
         if total_magnetization_normalized_formula_units:
             query_params.update(
                 {
-                    "total_magnetization_normalized_formula_units_min": total_magnetization_normalized_formula_units[
-                        0
-                    ],
-                    "total_magnetization_normalized_formula_units_max": total_magnetization_normalized_formula_units[
-                        1
-                    ],
+                    "total_magnetization_normalized_formula_units_min": total_magnetization_normalized_formula_units[0],
+                    "total_magnetization_normalized_formula_units_max": total_magnetization_normalized_formula_units[1],
                 }
             )
 
@@ -133,20 +121,10 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
             query_params.update({"ordering": ordering.value})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/materials.py
+++ b/mp_api/client/routes/materials.py
@@ -13,15 +13,12 @@ _EMMET_SETTINGS = EmmetSettings()
 
 
 class MaterialsRester(BaseRester[MaterialsDoc]):
-
     suffix = "materials"
     document_model = MaterialsDoc  # type: ignore
     supports_versions = True
     primary_key = "material_id"
 
-    def get_structure_by_material_id(
-        self, material_id: str, final: bool = True
-    ) -> Union[Structure, List[Structure]]:
+    def get_structure_by_material_id(self, material_id: str, final: bool = True) -> Union[Structure, List[Structure]]:
         """
         Get a structure for a given Materials Project ID.
 
@@ -47,8 +44,7 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
         """
 
         warnings.warn(
-            "MPRester.materials.search_material_docs is deprecated. "
-            "Please use MPRester.materials.search instead.",
+            "MPRester.materials.search_material_docs is deprecated. " "Please use MPRester.materials.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -148,16 +144,12 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
         )
 
         if num_sites:
-            query_params.update(
-                {"nsites_min": num_sites[0], "nsites_max": num_sites[1]}
-            )
+            query_params.update({"nsites_min": num_sites[0], "nsites_max": num_sites[1]})
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if volume:
             query_params.update({"volume_min": volume[0], "volume_max": volume[1]})
@@ -166,22 +158,12 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
             query_params.update({"density_min": density[0], "density_max": density[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )
 
     def find_structure(

--- a/mp_api/client/routes/molecules.py
+++ b/mp_api/client/routes/molecules.py
@@ -10,7 +10,6 @@ import warnings
 
 
 class MoleculesRester(BaseRester[MoleculesDoc]):
-
     suffix = "molecules"
     document_model = MoleculesDoc  # type: ignore
     primary_key = "task_id"
@@ -21,8 +20,7 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
         """
 
         warnings.warn(
-            "MPRester.molecules.search_molecules_docs is deprecated. "
-            "Please use MPRester.molecules.search instead.",
+            "MPRester.molecules.search_molecules_docs is deprecated. " "Please use MPRester.molecules.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -79,9 +77,7 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
             query_params.update({"smiles": smiles})
 
         if nelements:
-            query_params.update(
-                {"nelements_min": nelements[0], "nelements_max": nelements[1]}
-            )
+            query_params.update({"nelements_min": nelements[0], "nelements_max": nelements[1]})
 
         if EA:
             query_params.update({"EA_min": EA[0], "EA_max": EA[1]})
@@ -93,20 +89,10 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
             query_params.update({"charge_min": charge[0], "charge_max": charge[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/mpcules/summary.py
+++ b/mp_api/client/routes/mpcules/summary.py
@@ -9,9 +9,9 @@ from mp_api.client.core import BaseRester
 from mp_api.client.core.utils import validate_ids
 
 
-class MPculeSummaryRester(BaseRester[SummaryDoc]):
+class MPculesSummaryRester(BaseRester[SummaryDoc]):
 
-    suffix = "summary"
+    suffix = "mpcules_summary"
     document_model = SummaryDoc  # type: ignore
     primary_key = "molecule_id"
 

--- a/mp_api/client/routes/mpcules/summary.py
+++ b/mp_api/client/routes/mpcules/summary.py
@@ -20,25 +20,10 @@ class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
         charge: Optional[Tuple[int, int]] = None,
         spin_multiplicity: Optional[Tuple[int, int]] = None,
         nelements: Optional[Tuple[int, int]] = None,
-        has_solvent: Optional[Union[str, List[str]]] = None,
-        has_level_of_theory: Optional[Union[str, List[str]]] = None,
-        has_lot_solvent: Optional[Union[str, List[str]]] = None,
+        # has_solvent: Optional[Union[str, List[str]]] = None,
+        # has_level_of_theory: Optional[Union[str, List[str]]] = None,
+        # has_lot_solvent: Optional[Union[str, List[str]]] = None,
         # with_solvent: Optional[str] = None,
-        electronic_energy: Optional[Tuple[float, float]] = None,
-        ionization_energy: Optional[Tuple[float, float]] = None,
-        electron_affinity: Optional[Tuple[float, float]] = None,
-        reduction_free_energy: Optional[Tuple[float, float]] = None,
-        oxidation_free_energy: Optional[Tuple[float, float]] = None,
-        # zero_point_energy: Optional[Tuple[float, float]] = None,
-        # total_enthalpy: Optional[Tuple[float, float]] = None,
-        # total_entropy: Optional[Tuple[float, float]] = None,
-        # translational_enthalpy: Optional[Tuple[float, float]] = None,
-        # translational_entropy: Optional[Tuple[float, float]] = None,
-        # vibrational_enthalpy: Optional[Tuple[float, float]] = None,
-        # vibrational_entropy: Optional[Tuple[float, float]] = None,
-        # rotational_enthalpy: Optional[Tuple[float, float]] = None,
-        # rotational_entropy: Optional[Tuple[float, float]] = None,
-        # free_energy: Optional[Tuple[float, float]] = None,
         chemsys: Optional[Union[str, List[str]]] = None,
         deprecated: Optional[bool] = None,
         elements: Optional[List[str]] = None,
@@ -60,19 +45,14 @@ class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
             charge (Tuple[int, int]): Minimum and maximum charge for the molecule.
             spin_multiplicity (Tuple[int, int]): Minimum and maximum spin for the molecule.
             nelements (Tuple[int, int]): Minimum and maximum number of elements
-            has_solvent (str, List[str]): Whether the molecule has properties calculated in
-                solvents (e.g., "SOLVENT=THF", ["SOLVENT=WATER", "VACUUM"])
-            has_level_of_theory (str, List[str]): Whether the molecule has properties calculated
-                using a particular level of theory (e.g. "wB97M-V/def2-SVPD/SMD", 
-                    ["wB97X-V/def2-TZVPPD/SMD", "wB97M-V/def2-QZVPPD/SMD"])
-            has_lot_solvent (str, List[str]): Whether the molecule has properties calculated
-                using a particular combination of level of theory and solvent (e.g. "wB97X-V/def2-SVPD/SMD(SOLVENT=THF)", 
-                    ["wB97X-V/def2-TZVPPD/SMD(VACUUM)", "wB97M-V/def2-QZVPPD/SMD(SOLVENT=WATER)"])
-            electronic_energy (Tuple[float, float]): Minimum and maximum electronic energy
-            ionization_energy (Tuple[float, float]): Minimum and maximum ionization energy
-            electron_affinity (Tuple[float, float]): Minimum and maximum electron affinity
-            reduction_free_energy (Tuple[float, float]): Minimum and maximum reduction free energy
-            oxidation_free_energy (Tuple[float, float]): Minimum and maximum oxidation free energy
+            # has_solvent (str, List[str]): Whether the molecule has properties calculated in
+            #     solvents (e.g., "SOLVENT=THF", ["SOLVENT=WATER", "VACUUM"])
+            # has_level_of_theory (str, List[str]): Whether the molecule has properties calculated
+            #     using a particular level of theory (e.g. "wB97M-V/def2-SVPD/SMD", 
+            #         ["wB97X-V/def2-TZVPPD/SMD", "wB97M-V/def2-QZVPPD/SMD"])
+            # has_lot_solvent (str, List[str]): Whether the molecule has properties calculated
+            #     using a particular combination of level of theory and solvent (e.g. "wB97X-V/def2-SVPD/SMD(SOLVENT=THF)", 
+            #         ["wB97X-V/def2-TZVPPD/SMD(VACUUM)", "wB97M-V/def2-QZVPPD/SMD(SOLVENT=WATER)"])
             chemsys (str, List[str]): A chemical system, list of chemical systems
                 (e.g., Li-C-O, [C-O-H-N, Li-N]), or single formula (e.g., C2 H4).
             deprecated (bool): Whether the material is tagged as deprecated.

--- a/mp_api/client/routes/mpcules/summary.py
+++ b/mp_api/client/routes/mpcules/summary.py
@@ -47,7 +47,7 @@ class MPculeSummaryRester(BaseRester[SummaryDoc]):
         has_props: Optional[List[HasProps]] = None,
         material_ids: Optional[List[MPID]] = None,
         num_elements: Optional[Tuple[int, int]] = None,
-        num_sites: Optional[Tuple[int, int]] = None,
+        # num_sites: Optional[Tuple[int, int]] = None,
         sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
         chunk_size: int = 1000,
@@ -61,21 +61,28 @@ class MPculeSummaryRester(BaseRester[SummaryDoc]):
             charge (Tuple[int, int]): Minimum and maximum charge for the molecule.
             spin_multiplicity (Tuple[int, int]): Minimum and maximum spin for the molecule.
             nelements (Tuple[int, int]): Minimum and maximum number of elements
+            has_solvent (str, List[str]): Whether the molecule has properties calculated in
+                solvents (e.g., "SOLVENT=THF", ["SOLVENT=WATER", "VACUUM"])
+            has_level_of_theory (str, List[str]): Whether the molecule has properties calculated
+                using a particular level of theory (e.g. "wB97M-V/def2-SVPD/SMD", 
+                    ["wB97X-V/def2-TZVPPD/SMD", "wB97M-V/def2-QZVPPD/SMD"])
+            with_solvent (str): For property-based queries, ensure that the properties are calculated
+                in a particular solvent
+            electronic_energy (Tuple[float, float]): Minimum and maximum electronic energy
+            ionization_energy (Tuple[float, float]): Minimum and maximum ionization energy
+            electron_affinity (Tuple[float, float]): Minimum and maximum electron affinity
+            reduction_free_energy (Tuple[float, float]): Minimum and maximum reduction free energy
+            oxidation_free_energy (Tuple[float, float]): Minimum and maximum oxidation free energy
             chemsys (str, List[str]): A chemical system, list of chemical systems
                 (e.g., Li-C-O, [C-O-H-N, Li-N]), or single formula (e.g., C2 H4).
-            has_solvent (str, List[str]): Whether the molecule has properties calculated in
-                solvents (e.g., SOLVENT=THF, [SOLVENT=WATER, VACUUM])
-            # TODO: continue documentation
             deprecated (bool): Whether the material is tagged as deprecated.
             elements (List[str]): A list of elements.
             exclude_elements (List(str)): List of elements to exclude.
-            formula (str, List[str]): A formula including anonymized formula
-                or wild cards (e.g., Fe2O3, ABO3, Si*). A list of chemical formulas can also be passed
-                (e.g., [Fe2O3, ABO3]).
+            formula (str, List[str]): An alphabetical formula or list of formulas
+                (e.g. "C2 Li2 O4", ["C2 H4", "C2 H6"]).
             has_props: (List[HasProps]): The calculated properties available for the material.
             material_ids (List[MPID]): List of Materials Project IDs to return data for.
             num_elements (Tuple[int,int]): Minimum and maximum number of elements to consider.
-            num_sites (Tuple[int,int]): Minimum and maximum number of sites to consider.
             sort_fields (List[str]): Fields used to sort results. Prefixing with '-' will sort in descending order.
             num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.
             chunk_size (int): Number of data entries per chunk.
@@ -87,43 +94,6 @@ class MPculeSummaryRester(BaseRester[SummaryDoc]):
         """
 
         query_params = defaultdict(dict)  # type: dict
-
-        min_max_name_dict = {
-            "total_energy": "energy_per_atom",
-            "formation_energy": "formation_energy_per_atom",
-            "energy_above_hull": "energy_above_hull",
-            "uncorrected_energy": "uncorrected_energy_per_atom",
-            "equilibrium_reaction_energy": "equilibrium_reaction_energy_per_atom",
-            "nsites": "nsites",
-            "volume": "volume",
-            "density": "density",
-            "band_gap": "band_gap",
-            "efermi": "efermi",
-            "total_magnetization": "total_magnetization",
-            "total_magnetization_normalized_vol": "total_magnetization_normalized_vol",
-            "total_magnetization_normalized_formula_units": "total_magnetization_normalized_formula_units",
-            "num_magnetic_sites": "num_magnetic_sites",
-            "num_unique_magnetic_sites": "num_unique_magnetic_sites",
-            "k_voigt": "k_voigt",
-            "k_reuss": "k_reuss",
-            "k_vrh": "k_vrh",
-            "g_voigt": "g_voigt",
-            "g_reuss": "g_reuss",
-            "g_vrh": "g_vrh",
-            "elastic_anisotropy": "universal_anisotropy",
-            "poisson_ratio": "homogeneous_poisson",
-            "e_total": "e_total",
-            "e_ionic": "e_ionic",
-            "e_electronic": "e_electronic",
-            "n": "n",
-            "num_sites": "nsites",
-            "num_elements": "nelements",
-            "piezoelectric_modulus": "e_ij_max",
-            "weighted_surface_energy": "weighted_surface_energy",
-            "weighted_work_function": "weighted_work_function",
-            "surface_energy_anisotropy": "surface_anisotropy",
-            "shape_factor": "shape_factor",
-        }
 
         for param, value in locals().items():
             if param in min_max_name_dict and value:

--- a/mp_api/client/routes/mpcules/summary.py
+++ b/mp_api/client/routes/mpcules/summary.py
@@ -10,7 +10,6 @@ from mp_api.client.core.utils import validate_ids
 
 
 class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
-
     suffix = "mpcules"
     document_model = MoleculeSummaryDoc  # type: ignore
     primary_key = "molecule_id"
@@ -48,10 +47,11 @@ class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
             # has_solvent (str, List[str]): Whether the molecule has properties calculated in
             #     solvents (e.g., "SOLVENT=THF", ["SOLVENT=WATER", "VACUUM"])
             # has_level_of_theory (str, List[str]): Whether the molecule has properties calculated
-            #     using a particular level of theory (e.g. "wB97M-V/def2-SVPD/SMD", 
+            #     using a particular level of theory (e.g. "wB97M-V/def2-SVPD/SMD",
             #         ["wB97X-V/def2-TZVPPD/SMD", "wB97M-V/def2-QZVPPD/SMD"])
             # has_lot_solvent (str, List[str]): Whether the molecule has properties calculated
-            #     using a particular combination of level of theory and solvent (e.g. "wB97X-V/def2-SVPD/SMD(SOLVENT=THF)", 
+            #     using a particular combination of level of theory and solvent (e.g.
+            #         "wB97X-V/def2-SVPD/SMD(SOLVENT=THF)",
             #         ["wB97X-V/def2-TZVPPD/SMD(VACUUM)", "wB97M-V/def2-QZVPPD/SMD(SOLVENT=WATER)"])
             chemsys (str, List[str]): A chemical system, list of chemical systems
                 (e.g., Li-C-O, [C-O-H-N, Li-N]), or single formula (e.g., C2 H4).
@@ -82,7 +82,7 @@ class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
             "ionization_energy",
             "electron_affinity",
             "reduction_free_energy",
-            "oxidation_free_energy"
+            "oxidation_free_energy",
         ]
 
         for param, value in locals().items():
@@ -124,15 +124,9 @@ class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
             query_params.update({"has_props": ",".join([i.value for i in has_props])})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/mpcules/summary.py
+++ b/mp_api/client/routes/mpcules/summary.py
@@ -1,0 +1,212 @@
+import warnings
+from collections import defaultdict
+from typing import List, Optional, Tuple, Union
+
+from emmet.core.mpid import MPID
+from emmet.core.molecules.summary import HasProps, SummaryDoc
+
+from mp_api.client.core import BaseRester
+from mp_api.client.core.utils import validate_ids
+
+
+class MPculeSummaryRester(BaseRester[SummaryDoc]):
+
+    suffix = "summary"
+    document_model = SummaryDoc  # type: ignore
+    primary_key = "molecule_id"
+
+    def search(
+        self,
+        charge: Optional[Tuple[int, int]] = None,
+        spin_multiplicity: Optional[Tuple[int, int]] = None,
+        nelements: Optional[Tuple[int, int]] = None,
+        has_solvent: Optional[Union[str, List[str]]] = None,
+        has_level_of_theory: Optional[Union[str, List[str]]] = None,
+        has_lot_solvent: Optional[Union[str, List[str]]] = None,
+        with_solvent: Optional[str] = None,
+        electronic_energy: Optional[Tuple[float, float]] = None,
+        ionization_energy: Optional[Tuple[float, float]] = None,
+        electron_affinity: Optional[Tuple[float, float]] = None,
+        reduction_free_energy: Optional[Tuple[float, float]] = None,
+        oxidation_free_energy: Optional[Tuple[float, float]] = None,
+        # zero_point_energy: Optional[Tuple[float, float]] = None,
+        # total_enthalpy: Optional[Tuple[float, float]] = None,
+        # total_entropy: Optional[Tuple[float, float]] = None,
+        # translational_enthalpy: Optional[Tuple[float, float]] = None,
+        # translational_entropy: Optional[Tuple[float, float]] = None,
+        # vibrational_enthalpy: Optional[Tuple[float, float]] = None,
+        # vibrational_entropy: Optional[Tuple[float, float]] = None,
+        # rotational_enthalpy: Optional[Tuple[float, float]] = None,
+        # rotational_entropy: Optional[Tuple[float, float]] = None,
+        # free_energy: Optional[Tuple[float, float]] = None,
+        chemsys: Optional[Union[str, List[str]]] = None,
+        deprecated: Optional[bool] = None,
+        elements: Optional[List[str]] = None,
+        exclude_elements: Optional[List[str]] = None,
+        formula: Optional[Union[str, List[str]]] = None,
+        has_props: Optional[List[HasProps]] = None,
+        material_ids: Optional[List[MPID]] = None,
+        num_elements: Optional[Tuple[int, int]] = None,
+        num_sites: Optional[Tuple[int, int]] = None,
+        sort_fields: Optional[List[str]] = None,
+        num_chunks: Optional[int] = None,
+        chunk_size: int = 1000,
+        all_fields: bool = True,
+        fields: Optional[List[str]] = None,
+    ):
+        """
+        Query core data using a variety of search criteria.
+
+        Arguments:
+            charge (Tuple[int, int]): Minimum and maximum charge for the molecule.
+            spin_multiplicity (Tuple[int, int]): Minimum and maximum spin for the molecule.
+            nelements (Tuple[int, int]): Minimum and maximum number of elements
+            chemsys (str, List[str]): A chemical system, list of chemical systems
+                (e.g., Li-C-O, [C-O-H-N, Li-N]), or single formula (e.g., C2 H4).
+            has_solvent (str, List[str]): Whether the molecule has properties calculated in
+                solvents (e.g., SOLVENT=THF, [SOLVENT=WATER, VACUUM])
+            # TODO: continue documentation
+            deprecated (bool): Whether the material is tagged as deprecated.
+            elements (List[str]): A list of elements.
+            exclude_elements (List(str)): List of elements to exclude.
+            formula (str, List[str]): A formula including anonymized formula
+                or wild cards (e.g., Fe2O3, ABO3, Si*). A list of chemical formulas can also be passed
+                (e.g., [Fe2O3, ABO3]).
+            has_props: (List[HasProps]): The calculated properties available for the material.
+            material_ids (List[MPID]): List of Materials Project IDs to return data for.
+            num_elements (Tuple[int,int]): Minimum and maximum number of elements to consider.
+            num_sites (Tuple[int,int]): Minimum and maximum number of sites to consider.
+            sort_fields (List[str]): Fields used to sort results. Prefixing with '-' will sort in descending order.
+            num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.
+            chunk_size (int): Number of data entries per chunk.
+            all_fields (bool): Whether to return all fields in the document. Defaults to True.
+            fields (List[str]): List of fields in SearchDoc to return data for.
+                Default is material_id if all_fields is False.
+
+        Returns:
+        """
+
+        query_params = defaultdict(dict)  # type: dict
+
+        min_max_name_dict = {
+            "total_energy": "energy_per_atom",
+            "formation_energy": "formation_energy_per_atom",
+            "energy_above_hull": "energy_above_hull",
+            "uncorrected_energy": "uncorrected_energy_per_atom",
+            "equilibrium_reaction_energy": "equilibrium_reaction_energy_per_atom",
+            "nsites": "nsites",
+            "volume": "volume",
+            "density": "density",
+            "band_gap": "band_gap",
+            "efermi": "efermi",
+            "total_magnetization": "total_magnetization",
+            "total_magnetization_normalized_vol": "total_magnetization_normalized_vol",
+            "total_magnetization_normalized_formula_units": "total_magnetization_normalized_formula_units",
+            "num_magnetic_sites": "num_magnetic_sites",
+            "num_unique_magnetic_sites": "num_unique_magnetic_sites",
+            "k_voigt": "k_voigt",
+            "k_reuss": "k_reuss",
+            "k_vrh": "k_vrh",
+            "g_voigt": "g_voigt",
+            "g_reuss": "g_reuss",
+            "g_vrh": "g_vrh",
+            "elastic_anisotropy": "universal_anisotropy",
+            "poisson_ratio": "homogeneous_poisson",
+            "e_total": "e_total",
+            "e_ionic": "e_ionic",
+            "e_electronic": "e_electronic",
+            "n": "n",
+            "num_sites": "nsites",
+            "num_elements": "nelements",
+            "piezoelectric_modulus": "e_ij_max",
+            "weighted_surface_energy": "weighted_surface_energy",
+            "weighted_work_function": "weighted_work_function",
+            "surface_energy_anisotropy": "surface_anisotropy",
+            "shape_factor": "shape_factor",
+        }
+
+        for param, value in locals().items():
+            if param in min_max_name_dict and value:
+                if isinstance(value, (int, float)):
+                    value = (value, value)
+                query_params.update(
+                    {
+                        f"{min_max_name_dict[param]}_min": value[0],
+                        f"{min_max_name_dict[param]}_max": value[1],
+                    }
+                )
+
+        if material_ids:
+            query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
+
+        if deprecated is not None:
+            query_params.update({"deprecated": deprecated})
+
+        if formula:
+            if isinstance(formula, str):
+                formula = [formula]
+
+            query_params.update({"formula": ",".join(formula)})
+
+        if chemsys:
+            if isinstance(chemsys, str):
+                chemsys = [chemsys]
+
+            query_params.update({"chemsys": ",".join(chemsys)})
+
+        if elements:
+            query_params.update({"elements": ",".join(elements)})
+
+        if exclude_elements is not None:
+            query_params.update({"exclude_elements": ",".join(exclude_elements)})
+
+        if possible_species is not None:
+            query_params.update({"possible_species": ",".join(possible_species)})
+
+        query_params.update(
+            {
+                "crystal_system": crystal_system,
+                "spacegroup_number": spacegroup_number,
+                "spacegroup_symbol": spacegroup_symbol,
+            }
+        )
+
+        if is_stable is not None:
+            query_params.update({"is_stable": is_stable})
+
+        if is_gap_direct is not None:
+            query_params.update({"is_gap_direct": is_gap_direct})
+
+        if is_metal is not None:
+            query_params.update({"is_metal": is_metal})
+
+        if magnetic_ordering:
+            query_params.update({"ordering": magnetic_ordering.value})
+
+        if has_reconstructed is not None:
+            query_params.update({"has_reconstructed": has_reconstructed})
+
+        if has_props:
+            query_params.update({"has_props": ",".join([i.value for i in has_props])})
+
+        if theoretical is not None:
+            query_params.update({"theoretical": theoretical})
+
+        if sort_fields:
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
+
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
+
+        return super()._search(
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params,
+        )

--- a/mp_api/client/routes/mpcules/summary.py
+++ b/mp_api/client/routes/mpcules/summary.py
@@ -3,16 +3,16 @@ from collections import defaultdict
 from typing import List, Optional, Tuple, Union
 
 from emmet.core.mpid import MPculeID
-from emmet.core.molecules.summary import HasProps, SummaryDoc
+from emmet.core.molecules.summary import HasProps, MoleculeSummaryDoc
 
 from mp_api.client.core import BaseRester
 from mp_api.client.core.utils import validate_ids
 
 
-class MPculesSummaryRester(BaseRester[SummaryDoc]):
+class MPculesSummaryRester(BaseRester[MoleculeSummaryDoc]):
 
-    suffix = "mpcules_summary"
-    document_model = SummaryDoc  # type: ignore
+    suffix = "mpcules"
+    document_model = MoleculeSummaryDoc  # type: ignore
     primary_key = "molecule_id"
 
     def search(

--- a/mp_api/client/routes/oxidation_states.py
+++ b/mp_api/client/routes/oxidation_states.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 
 class OxidationStatesRester(BaseRester[OxidationStateDoc]):
-
     suffix = "oxidation_states"
     document_model = OxidationStateDoc  # type: ignore
     primary_key = "material_id"
@@ -70,20 +69,10 @@ class OxidationStatesRester(BaseRester[OxidationStateDoc]):
             query_params.update({"possible_species": ",".join(possible_species)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/phonon.py
+++ b/mp_api/client/routes/phonon.py
@@ -3,7 +3,6 @@ from emmet.core.phonon import PhononBSDOSDoc
 
 
 class PhononRester(BaseRester[PhononBSDOSDoc]):
-
     suffix = "phonon"
     document_model = PhononBSDOSDoc  # type: ignore
     primary_key = "material_id"

--- a/mp_api/client/routes/piezo.py
+++ b/mp_api/client/routes/piezo.py
@@ -9,7 +9,6 @@ import warnings
 
 
 class PiezoRester(BaseRester[PiezoelectricDoc]):
-
     suffix = "piezoelectric"
     document_model = PiezoelectricDoc  # type: ignore
     primary_key = "material_id"
@@ -74,20 +73,10 @@ class PiezoRester(BaseRester[PiezoelectricDoc]):
             )
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/provenance.py
+++ b/mp_api/client/routes/provenance.py
@@ -5,7 +5,6 @@ from typing import Optional, List, Union
 
 
 class ProvenanceRester(BaseRester[ProvenanceDoc]):
-
     suffix = "provenance"
     document_model = ProvenanceDoc  # type: ignore
     primary_key = "material_id"
@@ -45,9 +44,5 @@ class ProvenanceRester(BaseRester[ProvenanceDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/robocrys.py
+++ b/mp_api/client/routes/robocrys.py
@@ -7,7 +7,6 @@ import warnings
 
 
 class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
-
     suffix = "robocrys"
     document_model = RobocrystallogapherDoc  # type: ignore
     primary_key = "material_id"

--- a/mp_api/client/routes/similarity.py
+++ b/mp_api/client/routes/similarity.py
@@ -3,7 +3,6 @@ from emmet.core.similarity import SimilarityDoc
 
 
 class SimilarityRester(BaseRester[SimilarityDoc]):
-
     suffix = "similarity"
     document_model = SimilarityDoc  # type: ignore
     primary_key = "material_id"

--- a/mp_api/client/routes/substrates.py
+++ b/mp_api/client/routes/substrates.py
@@ -7,7 +7,6 @@ from emmet.core.substrates import SubstratesDoc
 
 
 class SubstratesRester(BaseRester[SubstratesDoc]):
-
     suffix = "substrates"
     document_model = SubstratesDoc  # type: ignore
     primary_key = "film_id"
@@ -76,18 +75,10 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
             query_params.update({"sub_form": substrate_formula})
 
         if film_orientation:
-            query_params.update(
-                {"film_orientation": ",".join([str(i) for i in film_orientation])}
-            )
+            query_params.update({"film_orientation": ",".join([str(i) for i in film_orientation])})
 
         if substrate_orientation:
-            query_params.update(
-                {
-                    "substrate_orientation": ",".join(
-                        [str(i) for i in substrate_orientation]
-                    )
-                }
-            )
+            query_params.update({"substrate_orientation": ",".join([str(i) for i in substrate_orientation])})
 
         if area:
             query_params.update({"area_min": area[0], "area_max": area[1]})
@@ -96,15 +87,9 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
             query_params.update({"energy_min": energy[0], "energy_max": energy[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             **query_params,

--- a/mp_api/client/routes/summary.py
+++ b/mp_api/client/routes/summary.py
@@ -12,7 +12,6 @@ from mp_api.client.core.utils import validate_ids
 
 
 class SummaryRester(BaseRester[SummaryDoc]):
-
     suffix = "summary"
     document_model = SummaryDoc  # type: ignore
     primary_key = "material_id"
@@ -23,8 +22,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
         """
 
         warnings.warn(
-            "MPRester.summary.search_summary_docs is deprecated. "
-            "Please use MPRester.summary.search instead.",
+            "MPRester.summary.search_summary_docs is deprecated. " "Please use MPRester.summary.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -77,9 +75,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
         theoretical: Optional[bool] = None,
         total_energy: Optional[Tuple[float, float]] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[
-            Tuple[float, float]
-        ] = None,
+        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
         uncorrected_energy: Optional[Tuple[float, float]] = None,
         volume: Optional[Tuple[float, float]] = None,
@@ -276,15 +272,9 @@ class SummaryRester(BaseRester[SummaryDoc]):
             query_params.update({"theoretical": theoretical})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/surface_properties.py
+++ b/mp_api/client/routes/surface_properties.py
@@ -8,7 +8,6 @@ import warnings
 
 
 class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
-
     suffix = "surface_properties"
     document_model = SurfacePropDoc  # type: ignore
     primary_key = "task_id"
@@ -100,20 +99,10 @@ class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
             query_params.update({"has_reconstructed": has_reconstructed})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/tasks.py
+++ b/mp_api/client/routes/tasks.py
@@ -9,7 +9,6 @@ from mp_api.client.core.utils import validate_ids
 
 
 class TaskRester(BaseRester[TaskDoc]):
-
     suffix = "tasks"
     document_model = TaskDoc  # type: ignore
     primary_key = "task_id"

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -12,7 +12,6 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ThermoRester(BaseRester[ThermoDoc]):
-
     suffix = "thermo"
     document_model = ThermoDoc  # type: ignore
     supports_versions = True

--- a/mp_api/client/routes/xas.py
+++ b/mp_api/client/routes/xas.py
@@ -9,7 +9,6 @@ import warnings
 
 
 class XASRester(BaseRester[XASDoc]):
-
     suffix = "xas"
     document_model = XASDoc  # type: ignore
     primary_key = "spectrum_id"
@@ -20,8 +19,7 @@ class XASRester(BaseRester[XASDoc]):
         """
 
         warnings.warn(
-            "MPRester.xas.search_xas_docs is deprecated. "
-            "Please use MPRester.xas.search instead.",
+            "MPRester.xas.search_xas_docs is deprecated. " "Please use MPRester.xas.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -99,9 +97,7 @@ class XASRester(BaseRester[XASDoc]):
             query_params["material_ids"] = ",".join(validate_ids(material_ids))
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
         return super()._search(
             num_chunks=num_chunks,

--- a/tests/mpcules/test_summary.py
+++ b/tests/mpcules/test_summary.py
@@ -15,13 +15,10 @@ excluded_params = [
     "exclude_elements",
     # Below: currently timing out
     "nelements",
-    "has_props"
+    "has_props",
 ]
 
-alt_name = {
-    "formula": "formula_alphabetical",
-    "molecule_ids": "molecule_id"
-}
+alt_name = {"formula": "formula_alphabetical", "molecule_ids": "molecule_id"}
 
 custom_field_tests = {
     "molecule_ids": ["9f153b9f3caa3124fb404b42e4cf82c8-C2H4-0-1"],
@@ -32,13 +29,12 @@ custom_field_tests = {
     "has_level_of_theory": "wB97X-V/def2-TZVPPD/SMD",
     "has_lot_solvent": "wB97X-V/def2-TZVPPD/SMD(SOLVENT=THF)",
     "nelements": 2,
-    "has_props": [HasProps.orbitals]
+    "has_props": [HasProps.orbitals],
 }  # type: dict
 
 
 @pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client():
-
     search_method = MPculesSummaryRester().search
 
     # Get list of parameters

--- a/tests/mpcules/test_summary.py
+++ b/tests/mpcules/test_summary.py
@@ -1,0 +1,77 @@
+from emmet.core.molecules.summary import HasProps
+from mp_api.client.routes.mpcules.summary import MPculesSummaryRester
+import os
+import pytest
+
+import typing
+
+excluded_params = [
+    "sort_fields",
+    "chunk_size",
+    "num_chunks",
+    "all_fields",
+    "fields",
+]
+
+custom_field_tests = {
+    "molecule_ids": ["9f153b9f3caa3124fb404b42e4cf82c8-C2H4-0-1"],
+    "formula": "C2 H4",
+    "chemsys": "C-H",
+    "elements": ["C", "H"],
+    "has_solvent": "DIELECTRIC=18,500;N=1,415;ALPHA=0,000;BETA=0,735;GAMMA=20,200;PHI=0,000;PSI=0,000",
+    "has_level_of_theory": "wB97X-V/def2-TZVPPD/SMD",
+    "has_lot_solvent": "wB97X-V/def2-TZVPPD/SMD(SOLVENT=THF)",
+    "nelements": 2,
+    "has_props": HasProps.orbitals
+}  # type: dict
+
+
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
+def test_client():
+
+    search_method = MPculesSummaryRester().search
+
+    # Get list of parameters
+    param_tuples = list(typing.get_type_hints(search_method).items())
+
+    # Query API for each numeric and boolean parameter and check if returned
+    for entry in param_tuples:
+        param = entry[0]
+        if param not in excluded_params:
+            param_type = entry[1].__args__[0]
+            q = None
+            print(param)
+
+            if param in custom_field_tests:
+                q = {
+                    param: custom_field_tests[param],
+                    "chunk_size": 1,
+                    "num_chunks": 1,
+                }
+            elif param_type == typing.Tuple[int, int]:
+                q = {
+                    param: (-100, 100),
+                    "chunk_size": 1,
+                    "num_chunks": 1,
+                }
+            elif param_type == typing.Tuple[float, float]:
+                q = {
+                    param: (-3000.12, 3000.12),
+                    "chunk_size": 1,
+                    "num_chunks": 1,
+                }
+            elif param_type is bool:
+                q = {
+                    param: False,
+                    "chunk_size": 1,
+                    "num_chunks": 1,
+                }
+
+            docs = search_method(**q)
+
+            if len(docs) > 0:
+                doc = docs[0].dict()
+            else:
+                raise ValueError("No documents returned")
+
+            assert doc[param] is not None

--- a/tests/mpcules/test_summary.py
+++ b/tests/mpcules/test_summary.py
@@ -11,7 +11,17 @@ excluded_params = [
     "num_chunks",
     "all_fields",
     "fields",
+    "has_solvent",
+    "exclude_elements",
+    # Below: currently timing out
+    "nelements",
+    "has_props"
 ]
+
+alt_name = {
+    "formula": "formula_alphabetical",
+    "molecule_ids": "molecule_id"
+}
 
 custom_field_tests = {
     "molecule_ids": ["9f153b9f3caa3124fb404b42e4cf82c8-C2H4-0-1"],
@@ -22,7 +32,7 @@ custom_field_tests = {
     "has_level_of_theory": "wB97X-V/def2-TZVPPD/SMD",
     "has_lot_solvent": "wB97X-V/def2-TZVPPD/SMD(SOLVENT=THF)",
     "nelements": 2,
-    "has_props": HasProps.orbitals
+    "has_props": [HasProps.orbitals]
 }  # type: dict
 
 
@@ -74,4 +84,4 @@ def test_client():
             else:
                 raise ValueError("No documents returned")
 
-            assert doc[param] is not None
+            assert doc[alt_name.get(param, param)] is not None

--- a/tests/test_bonds.py
+++ b/tests/test_bonds.py
@@ -36,11 +36,8 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
-
     search_method = rester.search
 
     if search_method is not None:
@@ -89,7 +86,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_charge_density.py
+++ b/tests/test_charge_density.py
@@ -83,7 +83,6 @@ def test_client(rester):
 
 
 def test_download_for_task_ids(tmpdir, rester):
-
     n = rester.download_for_task_ids(
         task_ids=["mp-655585", "mp-1057373", "mp-1059589", "mp-1440634", "mp-1791788"],
         path=tmpdir,
@@ -94,7 +93,6 @@ def test_download_for_task_ids(tmpdir, rester):
 
 
 def test_extract_s3_url_info(rester):
-
     url_doc_dict = {
         "task_id": "mp-1896591",
         "url": "https://minio.materialsproject.org/phuck/atomate_chgcar_fs/6021584c12afbe14911d1b8e",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -45,7 +45,6 @@ mpr = MPRester()
 @pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.parametrize("rester", mpr._all_resters)
 def test_generic_get_methods(rester):
-
     # -- Test generic search and get_data_by_id methods
     name = rester.suffix.replace("/", "_")
     if name not in ignore_generic:

--- a/tests/test_core_client.py
+++ b/tests/test_core_client.py
@@ -18,45 +18,31 @@ def mpr():
     rester.session.close()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.xfail
 def test_post_fail(rester):
     rester._post_resource({}, suburl="materials/find_structure")
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_pagination(mpr):
-    mpids = mpr.materials.search(
-        all_fields=False, fields=["material_id"], num_chunks=2, chunk_size=1000
-    )
+    mpids = mpr.materials.search(all_fields=False, fields=["material_id"], num_chunks=2, chunk_size=1000)
     assert len(mpids) > 1000
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_count(mpr):
-    count = mpr.materials.count(
-        dict(task_ids="mp-149", _all_fields=False, _fields="material_id")
-    )
+    count = mpr.materials.count(dict(task_ids="mp-149", _all_fields=False, _fields="material_id"))
     assert count == 1
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.xfail
 def test_get_document_no_id(mpr):
     mpr.materials.get_data_by_id(None)
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.xfail
 def test_get_document_no_doc(mpr):
     mpr.materials.get_data_by_id("mp-1a")

--- a/tests/test_dielectric.py
+++ b/tests/test_dielectric.py
@@ -32,9 +32,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -82,7 +80,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_elasticity.py
+++ b/tests/test_elasticity.py
@@ -30,9 +30,7 @@ alt_name_dict = {
 custom_field_tests = {}  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -80,7 +78,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_electrodes.py
+++ b/tests/test_electrodes.py
@@ -42,9 +42,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -92,7 +90,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_electronic_structure.py
+++ b/tests/test_electronic_structure.py
@@ -47,9 +47,7 @@ es_custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_es_client(es_rester):
     search_method = es_rester.search
 
@@ -61,7 +59,6 @@ def test_es_client(es_rester):
         for entry in param_tuples:
             param = entry[0]
             if param not in es_excluded_params:
-
                 param_type = entry[1].__args__[0]
                 q = None
 
@@ -96,10 +93,7 @@ def test_es_client(es_rester):
 
                 doc = search_method(**q)[0].dict()
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None
 
 
 bs_custom_field_tests = {
@@ -122,9 +116,7 @@ def bs_rester():
     rester.session.close()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_bs_client(bs_rester):
     # Get specific search method
     search_method = bs_rester.search
@@ -169,9 +161,7 @@ def dos_rester():
     rester.session.close()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_dos_client(dos_rester):
     search_method = dos_rester.search
 
@@ -192,6 +182,4 @@ def test_dos_client(dos_rester):
             if param != "projection_type" and param != "magnetic_ordering":
                 doc = doc["total"]["1"]
 
-            assert (
-                doc[project_field if project_field is not None else param] is not None
-            )
+            assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -27,9 +27,7 @@ alt_name_dict = {}  # type: dict
 custom_field_tests = {}  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -78,7 +76,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_grain_boundary.py
+++ b/tests/test_grain_boundary.py
@@ -36,9 +36,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -87,7 +85,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_magnetism.py
+++ b/tests/test_magnetism.py
@@ -28,9 +28,7 @@ alt_name_dict = {"material_ids": "material_id"}  # type: dict
 custom_field_tests = {"material_ids": ["mp-149"], "ordering": Ordering.FM}  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -79,7 +77,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_molecules.py
+++ b/tests/test_molecules.py
@@ -33,9 +33,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -84,7 +82,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -38,9 +38,7 @@ def mpr():
     rester.session.close()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 class TestMPRester:
     def test_get_structure_by_material_id(self, mpr):
         s1 = mpr.get_structure_by_material_id("mp-149")
@@ -147,9 +145,7 @@ class TestMPRester:
 
         # Conventional structure
         formula = "BiFeO3"
-        entry = mpr.get_entry_by_material_id(
-            "mp-22526", inc_structure=True, conventional_unit_cell=True
-        )[0]
+        entry = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=True)[0]
 
         s = entry.structure
         assert pytest.approx(s.lattice.a) == s.lattice.b
@@ -159,9 +155,7 @@ class TestMPRester:
         assert pytest.approx(s.lattice.gamma) == 120
 
         # Ensure energy per atom is same
-        prim = mpr.get_entry_by_material_id(
-            "mp-22526", inc_structure=True, conventional_unit_cell=False
-        )[0]
+        prim = mpr.get_entry_by_material_id("mp-22526", inc_structure=True, conventional_unit_cell=False)[0]
         assert pytest.approx(prim.energy_per_atom) == entry.energy_per_atom
 
         s = prim.structure
@@ -263,15 +257,9 @@ class TestMPRester:
 
         # test ion energy calculation
         ion_data = mpr.get_ion_reference_data_for_chemsys("S")
-        ion_ref_comps = [
-            Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data
-        ]
-        ion_ref_elts = set(
-            itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
-        )
-        ion_ref_entries = mpr.get_entries_in_chemsys(
-            list([str(e) for e in ion_ref_elts] + ["O", "H"])
-        )
+        ion_ref_comps = [Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data]
+        ion_ref_elts = set(itertools.chain.from_iterable(i.elements for i in ion_ref_comps))
+        ion_ref_entries = mpr.get_entries_in_chemsys(list([str(e) for e in ion_ref_elts] + ["O", "H"]))
         mpc = MaterialsProjectAqueousCompatibility()
         ion_ref_entries = mpc.process_entries(ion_ref_entries)
         ion_ref_pd = PhaseDiagram(ion_ref_entries)
@@ -280,9 +268,7 @@ class TestMPRester:
         # In ion ref data, SO4-2 is -744.27 kJ/mol; ref solid is -1,279.0 kJ/mol
         # so the ion entry should have an energy (-744.27 +1279) = 534.73 kJ/mol
         # or 5.542 eV/f.u. above the energy of Na2SO4
-        so4_two_minus = [e for e in ion_entries if e.ion.reduced_formula == "SO4[-2]"][
-            0
-        ]
+        so4_two_minus = [e for e in ion_entries if e.ion.reduced_formula == "SO4[-2]"][0]
 
         # the ref solid is Na2SO4, ground state mp-4770
         # the rf factor correction is necessary to make sure the composition
@@ -305,9 +291,7 @@ class TestMPRester:
         chgcar = mpr.get_charge_density_from_material_id("mp-149")
         assert isinstance(chgcar, Chgcar)
 
-        chgcar, task_doc = mpr.get_charge_density_from_material_id(
-            "mp-149", inc_task_doc=True
-        )
+        chgcar, task_doc = mpr.get_charge_density_from_material_id("mp-149", inc_task_doc=True)
         assert isinstance(chgcar, Chgcar)
         assert isinstance(task_doc, TaskDoc)
 
@@ -317,10 +301,7 @@ class TestMPRester:
 
     def test_large_list(self, mpr):
         mpids = [
-            str(doc.material_id)
-            for doc in mpr.summary.search(
-                chunk_size=1000, num_chunks=15, fields=["material_id"]
-            )
+            str(doc.material_id) for doc in mpr.summary.search(chunk_size=1000, num_chunks=15, fields=["material_id"])
         ]
         docs = mpr.summary.search(material_ids=mpids, fields=["material_ids"])
         assert len(docs) == 15000

--- a/tests/test_oxidation_states.py
+++ b/tests/test_oxidation_states.py
@@ -33,9 +33,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -47,7 +45,6 @@ def test_client(rester):
         for entry in param_tuples:
             param = entry[0]
             if param not in excluded_params:
-
                 param_type = entry[1].__args__[0]
                 q = None
 
@@ -85,7 +82,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_piezo.py
+++ b/tests/test_piezo.py
@@ -30,9 +30,7 @@ alt_name_dict = {
 custom_field_tests = {"material_ids": ["mp-9900"]}  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -81,7 +79,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -27,9 +27,7 @@ alt_name_dict = {"material_ids": "material_id"}  # type: dict
 custom_field_tests = {"material_ids": ["mp-149"]}  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -78,7 +76,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_robocrys.py
+++ b/tests/test_robocrys.py
@@ -12,14 +12,11 @@ def rester():
     rester.session.close()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
     if search_method is not None:
-
         q = {"keywords": ["silicon"], "num_chunks": 1}
 
         doc = search_method(**q)[0]

--- a/tests/test_substrates.py
+++ b/tests/test_substrates.py
@@ -38,9 +38,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -89,7 +87,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -56,7 +56,6 @@ custom_field_tests = {
 
 @pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client():
-
     search_method = SummaryRester().search
 
     # Get list of parameters

--- a/tests/test_surface_properties.py
+++ b/tests/test_surface_properties.py
@@ -27,9 +27,7 @@ alt_name_dict = {"surface_energy_anisotropy": "surface_anisotropy"}  # type: dic
 custom_field_tests = {}  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -78,7 +76,4 @@ def test_client(rester):
                     if sub_field in doc:
                         doc = doc[sub_field]
 
-                assert (
-                    doc[project_field if project_field is not None else param]
-                    is not None
-                )
+                assert doc[project_field if project_field is not None else param] is not None

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -15,9 +15,7 @@ def rester():
     rester.session.close()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 
@@ -31,9 +29,7 @@ def test_client(rester):
         assert doc.synthesis_type is not None
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_filters_keywords(rester):
     search_method = rester.search
 
@@ -45,25 +41,19 @@ def test_filters_keywords(rester):
         assert "silicon" in " ".join([x["value"] for x in highlighted]).lower()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_filters_synthesis_type(rester):
     search_method = rester.search
 
     if search_method is not None:
-        doc = search_method(
-            synthesis_type=[SynthesisTypeEnum.solid_state], num_chunks=1
-        )
+        doc = search_method(synthesis_type=[SynthesisTypeEnum.solid_state], num_chunks=1)
         assert all(x.synthesis_type == SynthesisTypeEnum.solid_state for x in doc)
 
         doc = search_method(synthesis_type=[SynthesisTypeEnum.sol_gel], num_chunks=1)
         assert all(x.synthesis_type == SynthesisTypeEnum.sol_gel for x in doc)
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.xfail  # Needs fixing
 def test_filters_temperature_range(rester):
     search_method = rester.search
@@ -81,9 +71,7 @@ def test_filters_temperature_range(rester):
                         assert 700 <= val <= 1000
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.xfail  # Needs fixing
 def test_filters_time_range(rester):
     search_method = rester.search
@@ -99,15 +87,14 @@ def test_filters_time_range(rester):
                         assert 7 <= val <= 11
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_filters_atmosphere(rester):
     search_method = rester.search
 
     if search_method is not None:
         docs: List[SynthesisRecipe] = search_method(
-            condition_heating_atmosphere=["air", "O2"], num_chunks=5,
+            condition_heating_atmosphere=["air", "O2"],
+            num_chunks=5,
         )
         for doc in docs:
             found = False
@@ -118,15 +105,14 @@ def test_filters_atmosphere(rester):
             assert found
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_filters_mixing_device(rester):
     search_method = rester.search
 
     if search_method is not None:
         docs: List[SynthesisRecipe] = search_method(
-            condition_mixing_device=["zirconia", "Al2O3"], num_chunks=5,
+            condition_mixing_device=["zirconia", "Al2O3"],
+            num_chunks=5,
         )
         for doc in docs:
             found = False
@@ -136,15 +122,14 @@ def test_filters_mixing_device(rester):
             assert found
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 def test_filters_mixing_media(rester):
     search_method = rester.search
 
     if search_method is not None:
         docs: List[SynthesisRecipe] = search_method(
-            condition_mixing_media=["water", "alcohol"], num_chunks=5,
+            condition_mixing_media=["water", "alcohol"],
+            num_chunks=5,
         )
         for doc in docs:
             found = False

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -26,7 +26,11 @@ excluded_params = [
 
 sub_doc_fields = []  # type: list
 
-alt_name_dict = {"formula": "task_id", "task_ids": "task_id", "exclude_elements": "task_id"}  # type: dict
+alt_name_dict = {
+    "formula": "task_id",
+    "task_ids": "task_id",
+    "exclude_elements": "task_id",
+}  # type: dict
 
 custom_field_tests = {
     "chemsys": "Si-O",
@@ -91,7 +95,6 @@ def test_client(rester):
 
 
 def test_get_trajectories(rester):
-
     trajectories = rester.get_trajectory("mp-149")
 
     for traj in trajectories:


### PR DESCRIPTION
This PR creates a RESTer for the MPcules summary endpoint. This should be the minimum required to create the upcoming Molecules Explorer Web app.

Known issues:
- For reasons unknown, querying on certain fields (nelements, has_props) is currently slow and can cause a timeout

Future work:
- Make RESTers for other MPcules endpoints