### PR TITLE
Small edit to add `backoff_factor` to client

### DIFF
--- a/mp_api/client/core/client.py
+++ b/mp_api/client/core/client.py
@@ -135,13 +135,15 @@ class BaseRester(Generic[T]):
             platform_info = f"{platform.system()}/{platform.release()}"
             session.headers["user-agent"] = f"{pymatgen_info} ({python_info} {platform_info})"
 
-        max_retry_num = MAPIClientSettings().MAX_RETRIES
+        settings = MAPIClientSettings()
+        max_retry_num = settings.MAX_RETRIES
         retry = Retry(
             total=max_retry_num,
             read=max_retry_num,
             connect=max_retry_num,
             respect_retry_after_header=True,
             status_forcelist=[429],  # rate limiting
+            backoff_factor=settings.BACKOFF_FACTOR
         )
         adapter = HTTPAdapter(max_retries=retry)
         session.mount("http://", adapter)

--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -62,7 +62,7 @@ class MAPIClientSettings(BaseSettings):
     MAX_RETRIES: int = Field(
         _MAX_RETRIES, description="Maximum number of retries for requests."
     )
-    
+
     BACKOFF_FACTOR: float = Field(
         0.1,
         description="A backoff factor to apply between retry attempts. To disable, set to 0.",

--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -63,7 +63,7 @@ class MAPIClientSettings(BaseSettings):
         _MAX_RETRIES, description="Maximum number of retries for requests."
     )
     
-    BACKOFF_FACTOR: float = FIELD(
+    BACKOFF_FACTOR: float = Field(
         0.1,
         description="A backoff factor to apply between retry attempts. To disable, set to 0.",
     )

--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -62,6 +62,11 @@ class MAPIClientSettings(BaseSettings):
     MAX_RETRIES: int = Field(
         _MAX_RETRIES, description="Maximum number of retries for requests."
     )
+    
+    BACKOFF_FACTOR: float = FIELD(
+        0.1,
+        description="A backoff factor to apply between retry attempts. To disable, set to 0.",
+    )
 
     MUTE_PROGRESS_BARS: bool = Field(
         _MUTE_PROGRESS_BAR,


### PR DESCRIPTION
This will introduce a delay between successive API calls if retries are required. A setting was added to make this optional/user-controllable.