### PR TITLE
Add support for nested endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,34 @@
+default_stages: [commit]
+
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.261
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: flake8
+      - id: ruff
+        args: [--fix, --ignore, "D,E501"]
+
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.3.0
     hooks:
-    - id: black
-      language_version: python3 # Should be a command that runs python3.6+
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v1.5.3
+      - id: black-jupyter
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
     hooks:
-    - id: autoflake
+      - id: check-case-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: destroyed-symlinks
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        stages: [commit, commit-msg]
+        exclude_types: [json, bib, svg]
+        args: [--ignore-words-list, "mater,fwe,te"]

--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -78,5 +78,9 @@ class MAPIClientSettings(BaseSettings):
         description="Number of characters to use to define the maximum length of a given HTTP URL.",
     )
 
+    MIN_EMMET_VERSION: str = Field(
+        "0.53.0", description="Minimum compatible version of emmet-core for the client."
+    )
+
     class Config:
         env_prefix = "MPRESTER_"

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -14,7 +14,7 @@ from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry
 from pymatgen.core import Element, Structure
 from pymatgen.core.ion import Ion
-from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
+from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.vasp import Chgcar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from requests import get, Session
@@ -22,7 +22,39 @@ from typing import Literal
 
 from mp_api.client.core import BaseRester, MPRestError
 from mp_api.client.core.utils import validate_ids
-from mp_api.client.routes import *
+from mp_api.client.routes import (
+    AlloysRester,
+    BandStructureRester,
+    BondsRester,
+    ChargeDensityRester,
+    DOIRester,
+    DielectricRester,
+    DosRester,
+    EOSRester,
+    ElasticityRester,
+    ElectrodeRester,
+    ElectronicStructureRester,
+    FermiRester,
+    GeneralStoreRester,
+    GrainBoundaryRester,
+    MagnetismRester,
+    MaterialsRester,
+    MoleculesRester,
+    OxidationStatesRester,
+    PhononRester,
+    PiezoRester,
+    ProvenanceRester,
+    RobocrysRester,
+    SimilarityRester,
+    SubstratesRester,
+    SummaryRester,
+    SurfacePropertiesRester,
+    SynthesisRester,
+    TaskRester,
+    ThermoRester,
+    UserSettingsRester,
+    XASRester,
+)
 
 _DEPRECATION_WARNING = (
     "MPRester is being modernized. Please use the new method suggested and "
@@ -132,7 +164,9 @@ class MPRester:
         self.endpoint = endpoint
         self.headers = headers or {}
         self.session = session or BaseRester._create_session(
-            api_key=self.api_key, include_user_agent=include_user_agent, headers=self.headers
+            api_key=self.api_key,
+            include_user_agent=include_user_agent,
+            headers=self.headers,
         )
         self.use_document_model = use_document_model
         self.monty_decode = monty_decode
@@ -174,11 +208,24 @@ class MPRester:
 
             self._all_resters.append(rester)
 
-            setattr(
-                self,
-                cls.suffix.replace("/", "_"),  # type: ignore
-                rester,
-            )
+            suffix_split = cls.suffix.split("/")
+
+            if len(suffix_split) == 1 or cls.suffix in [
+                "materials/core",
+                "molecules/core",
+            ]:
+                setattr(
+                    self,
+                    cls.suffix.split("/")[0],
+                    rester,
+                )
+
+            else:
+                setattr(
+                    self,
+                    "_".join(suffix_split[1:]),
+                    rester,
+                )
 
     def __enter__(self):
         """
@@ -200,10 +247,13 @@ class MPRester:
             )
         elif attr == "charge_density":
             raise MPRestError(
-                "boto3 not installed. " "To query charge density data first install with: 'pip install boto3'"
+                "boto3 not installed. "
+                "To query charge density data first install with: 'pip install boto3'"
             )
         else:
-            raise AttributeError(f"{self.__class__.__name__!r} object has no attribute {attr!r}")
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
+            )
 
     def get_task_ids_associated_with_material_id(
         self, material_id: str, calc_types: Optional[List[CalcType]] = None
@@ -214,9 +264,13 @@ class MPRester:
         :param calc_types: if specified, will restrict to certain task types, e.g. [CalcType.GGA_STATIC]
         :return:
         """
-        tasks = self.materials.get_data_by_id(material_id, fields=["calc_types"]).calc_types
+        tasks = self.materials.get_data_by_id(
+            material_id, fields=["calc_types"]
+        ).calc_types
         if calc_types:
-            return [task for task, calc_type in tasks.items() if calc_type in calc_types]
+            return [
+                task for task, calc_type in tasks.items() if calc_type in calc_types
+            ]
         else:
             return list(tasks.keys())
 
@@ -238,14 +292,19 @@ class MPRester:
             Structure object or list of Structure objects.
         """
 
-        structure_data = self.materials.get_structure_by_material_id(material_id=material_id, final=final)
+        structure_data = self.materials.get_structure_by_material_id(
+            material_id=material_id, final=final
+        )
 
         if conventional_unit_cell and structure_data:
             if final:
-                structure_data = SpacegroupAnalyzer(structure_data).get_conventional_standard_structure()
+                structure_data = SpacegroupAnalyzer(
+                    structure_data
+                ).get_conventional_standard_structure()
             else:
                 structure_data = [
-                    SpacegroupAnalyzer(structure).get_conventional_standard_structure() for structure in structure_data
+                    SpacegroupAnalyzer(structure).get_conventional_standard_structure()
+                    for structure in structure_data
                 ]
 
         return structure_data
@@ -284,7 +343,9 @@ class MPRester:
         if len(docs) == 1:  # pragma: no cover
             return str(docs[0].material_id)  # type: ignore
         elif len(docs) > 1:  # pragma: no cover
-            raise ValueError(f"Multiple documents return for {task_id}, this should not happen, please report it!")
+            raise ValueError(
+                f"Multiple documents return for {task_id}, this should not happen, please report it!"
+            )
         else:  # pragma: no cover
             warnings.warn(
                 f"No material found containing task {task_id}. Please report it if you suspect a task has gone missing."
@@ -338,7 +399,9 @@ class MPRester:
             List of all materials ids ([MPID])
         """
 
-        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
+        if isinstance(chemsys_formula, list) or (
+            isinstance(chemsys_formula, str) and "-" in chemsys_formula
+        ):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -365,7 +428,9 @@ class MPRester:
         )
         return self.get_material_ids(chemsys_formula)
 
-    def get_structures(self, chemsys_formula: Union[str, List[str]], final=True) -> List[Structure]:
+    def get_structures(
+        self, chemsys_formula: Union[str, List[str]], final=True
+    ) -> List[Structure]:
         """
         Get a list of Structures corresponding to a chemical system or formula.
 
@@ -379,7 +444,9 @@ class MPRester:
             List of Structure objects. ([Structure])
         """
 
-        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
+        if isinstance(chemsys_formula, list) or (
+            isinstance(chemsys_formula, str) and "-" in chemsys_formula
+        ):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -533,7 +600,11 @@ class MPRester:
             )
 
         for doc in docs:
-            entry_list = doc.entries.values() if self.use_document_model else doc["entries"].values()
+            entry_list = (
+                doc.entries.values()
+                if self.use_document_model
+                else doc["entries"].values()
+            )
             for entry in entry_list:
                 entry_dict = entry.as_dict() if self.monty_decode else entry
                 if not compatible_only:
@@ -543,13 +614,17 @@ class MPRester:
                 if property_data:
                     for property in property_data:
                         entry_dict["data"][property] = (
-                            doc.dict()[property] if self.use_document_model else doc[property]
+                            doc.dict()[property]
+                            if self.use_document_model
+                            else doc[property]
                         )
 
                 if conventional_unit_cell:
 
                     entry_struct = Structure.from_dict(entry_dict["structure"])
-                    s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
+                    s = SpacegroupAnalyzer(
+                        entry_struct
+                    ).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
                     new_energy = entry_dict["energy"] * site_ratio
 
@@ -563,7 +638,11 @@ class MPRester:
                     for correction in entry_dict["energy_adjustments"]:
                         correction["n_atoms"] *= site_ratio
 
-                entry = ComputedStructureEntry.from_dict(entry_dict) if self.monty_decode else entry_dict
+                entry = (
+                    ComputedStructureEntry.from_dict(entry_dict)
+                    if self.monty_decode
+                    else entry_dict
+                )
 
                 entries.append(entry)
 
@@ -631,8 +710,12 @@ class MPRester:
         ion_data = self.get_ion_reference_data_for_chemsys(chemsys)
 
         # build the PhaseDiagram for get_ion_entries
-        ion_ref_comps = [Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data]
-        ion_ref_elts = set(itertools.chain.from_iterable(i.elements for i in ion_ref_comps))
+        ion_ref_comps = [
+            Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data
+        ]
+        ion_ref_elts = set(
+            itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
+        )
         # TODO - would be great if the commented line below would work
         # However for some reason you cannot process GibbsComputedStructureEntry with
         # MaterialsProjectAqueousCompatibility
@@ -651,7 +734,9 @@ class MPRester:
             compat = MaterialsProjectAqueousCompatibility(solid_compat=solid_compat)
         # suppress the warning about missing oxidation states
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Failed to guess oxidation states.*")
+            warnings.filterwarnings(
+                "ignore", message="Failed to guess oxidation states.*"
+            )
             ion_ref_entries = compat.process_entries(ion_ref_entries)
         # TODO - if the commented line above would work, this conditional block
         # could be removed
@@ -659,21 +744,32 @@ class MPRester:
             # replace the entries with GibbsComputedStructureEntry
             from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
-            ion_ref_entries = GibbsComputedStructureEntry.from_entries(ion_ref_entries, temp=use_gibbs)
+            ion_ref_entries = GibbsComputedStructureEntry.from_entries(
+                ion_ref_entries, temp=use_gibbs
+            )
         ion_ref_pd = PhaseDiagram(ion_ref_entries)
 
         ion_entries = self.get_ion_entries(ion_ref_pd, ion_ref_data=ion_data)
         pbx_entries = [PourbaixEntry(e, f"ion-{n}") for n, e in enumerate(ion_entries)]
 
         # Construct the solid pourbaix entries from filtered ion_ref entries
-        extra_elts = set(ion_ref_elts) - {Element(s) for s in chemsys} - {Element("H"), Element("O")}
+        extra_elts = (
+            set(ion_ref_elts)
+            - {Element(s) for s in chemsys}
+            - {Element("H"), Element("O")}
+        )
         for entry in ion_ref_entries:
             entry_elts = set(entry.composition.elements)
             # Ensure no OH chemsys or extraneous elements from ion references
-            if not (entry_elts <= {Element("H"), Element("O")} or extra_elts.intersection(entry_elts)):
+            if not (
+                entry_elts <= {Element("H"), Element("O")}
+                or extra_elts.intersection(entry_elts)
+            ):
                 # Create new computed entry
                 form_e = ion_ref_pd.get_form_energy(entry)
-                new_entry = ComputedEntry(entry.composition, form_e, entry_id=entry.entry_id)
+                new_entry = ComputedEntry(
+                    entry.composition, form_e, entry_id=entry.entry_id
+                )
                 pbx_entry = PourbaixEntry(new_entry)
                 pbx_entries.append(pbx_entry)
 
@@ -710,10 +806,14 @@ class MPRester:
                 compounds and aqueous species, Wiley, New York (1978)'}}
         """
         return self.contribs.query_contributions(
-            query={"project": "ion_ref_data"}, fields=["identifier", "formula", "data"], paginate=True
+            query={"project": "ion_ref_data"},
+            fields=["identifier", "formula", "data"],
+            paginate=True,
         ).get("data")
 
-    def get_ion_reference_data_for_chemsys(self, chemsys: Union[str, List]) -> List[Dict]:
+    def get_ion_reference_data_for_chemsys(
+        self, chemsys: Union[str, List]
+    ) -> List[Dict]:
         """
         Download aqueous ion reference data used in the construction of Pourbaix diagrams.
 
@@ -752,7 +852,9 @@ class MPRester:
 
         return [d for d in ion_data if d["data"]["MajElements"] in chemsys]
 
-    def get_ion_entries(self, pd: PhaseDiagram, ion_ref_data: List[dict] = None) -> List[IonEntry]:
+    def get_ion_entries(
+        self, pd: PhaseDiagram, ion_ref_data: List[dict] = None
+    ) -> List[IonEntry]:
         """
         Retrieve IonEntry objects that can be used in the construction of
         Pourbaix Diagrams. The energies of the IonEntry are calculaterd from
@@ -786,7 +888,8 @@ class MPRester:
         # raise ValueError if O and H not in chemsys
         if "O" not in chemsys or "H" not in chemsys:
             raise ValueError(
-                "The phase diagram chemical system must contain O and H! Your" f" diagram chemical system is {chemsys}."
+                "The phase diagram chemical system must contain O and H! Your"
+                f" diagram chemical system is {chemsys}."
             )
 
         if not ion_ref_data:
@@ -798,7 +901,11 @@ class MPRester:
         ion_entries = []
         for n, i_d in enumerate(ion_data):
             ion = Ion.from_formula(i_d["formula"])
-            refs = [e for e in pd.all_entries if e.composition.reduced_formula == i_d["data"]["RefSolid"]]
+            refs = [
+                e
+                for e in pd.all_entries
+                if e.composition.reduced_formula == i_d["data"]["RefSolid"]
+            ]
             if not refs:
                 raise ValueError("Reference solid not contained in entry list")
             stable_ref = sorted(refs, key=lambda x: x.energy_per_atom)[0]
@@ -813,7 +920,9 @@ class MPRester:
                 # convert to eV/formula unit
                 ref_solid_energy = i_d["data"]["ΔGᶠRefSolid"]["value"] / 96485
             else:
-                raise ValueError(f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}")
+                raise ValueError(
+                    f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}"
+                )
             solid_diff = pd.get_form_energy(stable_ref) - ref_solid_energy * rf
             elt = i_d["data"]["MajElements"]
             correction_factor = ion.composition[elt] / stable_ref.composition[elt]
@@ -826,7 +935,9 @@ class MPRester:
                 # convert to eV/formula unit
                 ion_free_energy = i_d["data"]["ΔGᶠ"]["value"] / 96485
             else:
-                raise ValueError(f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}")
+                raise ValueError(
+                    f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}"
+                )
             energy = ion_free_energy + solid_diff * correction_factor
             ion_entries.append(IonEntry(ion, energy))
 
@@ -1054,8 +1165,12 @@ class MPRester:
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
         structure = self.get_structure_by_material_id(material_id)
-        surfaces = surfaces = self.surface_properties.get_data_by_id(material_id).surfaces
-        lattice = SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
+        surfaces = surfaces = self.surface_properties.get_data_by_id(
+            material_id
+        ).surfaces
+        lattice = (
+            SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
+        )
         miller_energy_map = {}
         for surf in surfaces:
             miller = tuple(surf.miller_index)
@@ -1065,7 +1180,9 @@ class MPRester:
         millers, energies = zip(*miller_energy_map.items())
         return WulffShape(lattice, millers, energies)
 
-    def get_charge_density_from_material_id(self, material_id: str, inc_task_doc: bool = False) -> Optional[Chgcar]:
+    def get_charge_density_from_material_id(
+        self, material_id: str, inc_task_doc: bool = False
+    ) -> Optional[Chgcar]:
         """
         Get charge density data for a given Materials Project ID.
 
@@ -1078,7 +1195,10 @@ class MPRester:
         """
 
         if not hasattr(self, "charge_density"):
-            raise MPRestError("boto3 not installed. " "To query charge density data install the boto3 package.")
+            raise MPRestError(
+                "boto3 not installed. "
+                "To query charge density data install the boto3 package."
+            )
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity
@@ -1117,11 +1237,16 @@ class MPRester:
             metadata info, e.g. the task/external_ids that belong to a directory
         """
         # task_id's correspond to NoMaD external_id's
-        calc_types = [t.value for t in calc_types if isinstance(t, CalcType)] if calc_types else []
+        calc_types = (
+            [t.value for t in calc_types if isinstance(t, CalcType)]
+            if calc_types
+            else []
+        )
 
         meta = {}
         for doc in self.materials.search(
-            task_ids=material_ids, fields=["calc_types", "deprecated_tasks", "material_id"]
+            task_ids=material_ids,
+            fields=["calc_types", "deprecated_tasks", "material_id"],
         ):
 
             for task_id, calc_type in doc.calc_types.items():
@@ -1147,9 +1272,13 @@ class MPRester:
         prefix += "external_id="
 
         task_ids = [t["task_id"] for tl in meta.values() for t in tl]
-        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(prefix=prefix, task_ids=task_ids)
+        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(
+            prefix=prefix, task_ids=task_ids
+        )
         if len(nomad_exist_task_ids) != len(task_ids):
-            self._print_help_message(nomad_exist_task_ids, task_ids, file_patterns, calc_types)
+            self._print_help_message(
+                nomad_exist_task_ids, task_ids, file_patterns, calc_types
+            )
 
         # generate download links for those that exist
         prefix = "https://nomad-lab.eu/prod/rae/api/raw/query?"

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -209,7 +209,6 @@ class MPRester:
             self.endpoint += "/"
 
         for cls in BaseRester.__subclasses__():
-
             rester = cls(
                 api_key=api_key,
                 endpoint=endpoint,
@@ -595,7 +594,6 @@ class MPRester:
         try:
             input_params = {"material_ids": validate_ids(chemsys_formula_mpids)}
         except ValueError:
-
             if any("-" in entry for entry in chemsys_formula_mpids):
                 input_params = {"chemsys": chemsys_formula_mpids}
             else:
@@ -643,7 +641,6 @@ class MPRester:
                         )
 
                 if conventional_unit_cell:
-
                     entry_struct = Structure.from_dict(entry_dict["structure"])
                     s = SpacegroupAnalyzer(
                         entry_struct
@@ -1271,7 +1268,6 @@ class MPRester:
             task_ids=material_ids,
             fields=["calc_types", "deprecated_tasks", "material_id"],
         ):
-
             for task_id, calc_type in doc.calc_types.items():
                 if calc_types and calc_type not in calc_types:
                     continue

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -19,9 +19,11 @@ from pymatgen.io.vasp import Chgcar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from requests import get, Session
 from typing import Literal
+from packaging import version
 
 from mp_api.client.core import BaseRester, MPRestError
 from mp_api.client.core.utils import validate_ids
+from mp_api.client.core.settings import MAPIClientSettings
 from mp_api.client.routes import (
     AlloysRester,
     BandStructureRester,
@@ -63,6 +65,7 @@ _DEPRECATION_WARNING = (
 )
 
 _EMMET_SETTINGS = EmmetSettings()
+_MAPI_SETTINGS = MAPIClientSettings()
 
 DEFAULT_API_KEY = environ.get("MP_API_KEY", None)
 DEFAULT_ENDPOINT = environ.get("MP_API_ENDPOINT", "https://api.materialsproject.org/")
@@ -185,6 +188,17 @@ class MPRester:
         except Exception as error:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")
+
+        # Check if emmet version of server os compatible
+        emmet_version = version.parse(self.get_emmet_version())
+
+        if version.parse(emmet_version.base_version) < version.parse(
+            _MAPI_SETTINGS.MIN_EMMET_VERSION
+        ):
+            warnings.warn(
+                "The installed version of the mp-api client may not be compatible with the API server. "
+                "Please install a previous version if any problems occur."
+            )
 
         self._all_resters = []
 
@@ -324,6 +338,15 @@ class MPRester:
         Returns: database version as a string
         """
         return get(url=self.endpoint + "heartbeat").json()["db_version"]
+
+    def get_emmet_version(self):
+        """
+        Get the latest version emmet-core and emmet-api used in the
+        current API service.
+
+        Returns: version as a string
+        """
+        return get(url=self.endpoint + "heartbeat").json()["version"]
 
     def get_material_id_from_task_id(self, task_id: str) -> Union[str, None]:
         """

--- a/mp_api/client/routes/alloys.py
+++ b/mp_api/client/routes/alloys.py
@@ -8,7 +8,7 @@ from emmet.core.alloys import AlloyPairDoc
 
 class AlloysRester(BaseRester[AlloyPairDoc]):
 
-    suffix = "alloys"
+    suffix = "materials/alloys"
     document_model = AlloyPairDoc  # type: ignore
     primary_key = "pair_id"
 

--- a/mp_api/client/routes/bonds.py
+++ b/mp_api/client/routes/bonds.py
@@ -10,7 +10,7 @@ import warnings
 
 class BondsRester(BaseRester[BondingDoc]):
 
-    suffix = "bonds"
+    suffix = "materials/bonds"
     document_model = BondingDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/charge_density.py
+++ b/mp_api/client/routes/charge_density.py
@@ -17,7 +17,7 @@ from mp_api.client.core.utils import validate_ids
 
 class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
 
-    suffix = "charge_density"
+    suffix = "materials/charge_density"
     primary_key = "fs_id"
     document_model = ChgcarDataDoc  # type: ignore
     boto_resource = None
@@ -50,7 +50,11 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
         return num_downloads
 
     def search(  # type: ignore
-        self, task_ids: Optional[List[str]] = None, num_chunks: Optional[int] = 1, chunk_size: int = 10, **kwargs
+        self,
+        task_ids: Optional[List[str]] = None,
+        num_chunks: Optional[int] = 1,
+        chunk_size: int = 10,
+        **kwargs,
     ) -> Union[List[ChgcarDataDoc], List[Dict]]:  # type: ignore
         """
         A search method to find what charge densities are available via this API.
@@ -88,7 +92,9 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
             if environ.get("AWS_EXECUTION_ENV", None) == "AWS_ECS_FARGATE":
 
                 if self.boto_resource is None:
-                    self.boto_resource = self._get_s3_resource(use_minio=False, unsigned=False)
+                    self.boto_resource = self._get_s3_resource(
+                        use_minio=False, unsigned=False
+                    )
 
                 bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
 
@@ -102,7 +108,9 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
                 except ConnectionError:
                     self.boto_resource = self._get_s3_resource(use_minio=False)
 
-                    bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
+                    bucket, obj_prefix = self._extract_s3_url_info(
+                        url_doc, use_minio=False
+                    )
 
             r = self.boto_resource.Object(bucket, f"{obj_prefix}/{url_doc.fs_id}").get()["Body"]  # type: ignore
 

--- a/mp_api/client/routes/dielectric.py
+++ b/mp_api/client/routes/dielectric.py
@@ -10,7 +10,7 @@ import warnings
 
 class DielectricRester(BaseRester[DielectricDoc]):
 
-    suffix = "dielectric"
+    suffix = "materials/dielectric"
     document_model = DielectricDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/elasticity.py
+++ b/mp_api/client/routes/elasticity.py
@@ -9,7 +9,7 @@ import warnings
 
 class ElasticityRester(BaseRester[ElasticityDoc]):
 
-    suffix = "elasticity"
+    suffix = "materials/elasticity"
     document_model = ElasticityDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/electrodes.py
+++ b/mp_api/client/routes/electrodes.py
@@ -10,7 +10,7 @@ from pymatgen.core.periodic_table import Element
 
 class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
 
-    suffix = "insertion_electrodes"
+    suffix = "materials/insertion_electrodes"
     document_model = InsertionElectrodeDoc  # type: ignore
     primary_key = "battery_id"
 

--- a/mp_api/client/routes/electronic_structure.py
+++ b/mp_api/client/routes/electronic_structure.py
@@ -21,7 +21,7 @@ from mp_api.client.core.utils import validate_ids
 
 class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
 
-    suffix = "electronic_structure"
+    suffix = "materials/electronic_structure"
     document_model = ElectronicStructureDoc  # type: ignore
     primary_key = "material_id"
 
@@ -160,7 +160,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
 
 class BandStructureRester(BaseRester):
 
-    suffix = "electronic_structure/bandstructure"
+    suffix = "materials/electronic_structure/bandstructure"
     document_model = ElectronicStructureDoc  # type: ignore
 
     def search_bandstructure_summary(self, *args, **kwargs):  # pragma: no cover
@@ -350,7 +350,7 @@ class BandStructureRester(BaseRester):
 
 class DosRester(BaseRester):
 
-    suffix = "electronic_structure/dos"
+    suffix = "materials/electronic_structure/dos"
     document_model = ElectronicStructureDoc  # type: ignore
 
     def search_dos_summary(self, *args, **kwargs):  # pragma: no cover

--- a/mp_api/client/routes/eos.py
+++ b/mp_api/client/routes/eos.py
@@ -9,7 +9,7 @@ import warnings
 
 class EOSRester(BaseRester[EOSDoc]):
 
-    suffix = "eos"
+    suffix = "materials/eos"
     document_model = EOSDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/fermi.py
+++ b/mp_api/client/routes/fermi.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 
 class FermiRester(BaseRester[FermiDoc]):
 
-    suffix = "fermi"
+    suffix = "materials/fermi"
     document_model = FermiDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/grain_boundary.py
+++ b/mp_api/client/routes/grain_boundary.py
@@ -11,7 +11,7 @@ import warnings
 
 class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
 
-    suffix = "grain_boundary"
+    suffix = "materials/grain_boundary"
     document_model = GrainBoundaryDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/magnetism.py
+++ b/mp_api/client/routes/magnetism.py
@@ -12,7 +12,7 @@ import warnings
 
 class MagnetismRester(BaseRester[MagnetismDoc]):
 
-    suffix = "magnetism"
+    suffix = "materials/magnetism"
     document_model = MagnetismDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/materials.py
+++ b/mp_api/client/routes/materials.py
@@ -14,7 +14,7 @@ _EMMET_SETTINGS = EmmetSettings()
 
 class MaterialsRester(BaseRester[MaterialsDoc]):
 
-    suffix = "materials"
+    suffix = "materials/core"
     document_model = MaterialsDoc  # type: ignore
     supports_versions = True
     primary_key = "material_id"

--- a/mp_api/client/routes/molecules.py
+++ b/mp_api/client/routes/molecules.py
@@ -11,7 +11,7 @@ import warnings
 
 class MoleculesRester(BaseRester[MoleculesDoc]):
 
-    suffix = "molecules"
+    suffix = "legacy/jcesr"
     document_model = MoleculesDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/oxidation_states.py
+++ b/mp_api/client/routes/oxidation_states.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 class OxidationStatesRester(BaseRester[OxidationStateDoc]):
 
-    suffix = "oxidation_states"
+    suffix = "materials/oxidation_states"
     document_model = OxidationStateDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/phonon.py
+++ b/mp_api/client/routes/phonon.py
@@ -4,7 +4,7 @@ from emmet.core.phonon import PhononBSDOSDoc
 
 class PhononRester(BaseRester[PhononBSDOSDoc]):
 
-    suffix = "phonon"
+    suffix = "materials/phonon"
     document_model = PhononBSDOSDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/piezo.py
+++ b/mp_api/client/routes/piezo.py
@@ -10,7 +10,7 @@ import warnings
 
 class PiezoRester(BaseRester[PiezoelectricDoc]):
 
-    suffix = "piezoelectric"
+    suffix = "materials/piezoelectric"
     document_model = PiezoelectricDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/provenance.py
+++ b/mp_api/client/routes/provenance.py
@@ -6,7 +6,7 @@ from typing import Optional, List, Union
 
 class ProvenanceRester(BaseRester[ProvenanceDoc]):
 
-    suffix = "provenance"
+    suffix = "materials/provenance"
     document_model = ProvenanceDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/robocrys.py
+++ b/mp_api/client/routes/robocrys.py
@@ -8,7 +8,7 @@ import warnings
 
 class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
 
-    suffix = "robocrys"
+    suffix = "materials/robocrys"
     document_model = RobocrystallogapherDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/similarity.py
+++ b/mp_api/client/routes/similarity.py
@@ -4,7 +4,7 @@ from emmet.core.similarity import SimilarityDoc
 
 class SimilarityRester(BaseRester[SimilarityDoc]):
 
-    suffix = "similarity"
+    suffix = "materials/similarity"
     document_model = SimilarityDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/substrates.py
+++ b/mp_api/client/routes/substrates.py
@@ -8,7 +8,7 @@ from emmet.core.substrates import SubstratesDoc
 
 class SubstratesRester(BaseRester[SubstratesDoc]):
 
-    suffix = "substrates"
+    suffix = "materials/substrates"
     document_model = SubstratesDoc  # type: ignore
     primary_key = "film_id"
 

--- a/mp_api/client/routes/summary.py
+++ b/mp_api/client/routes/summary.py
@@ -13,7 +13,7 @@ from mp_api.client.core.utils import validate_ids
 
 class SummaryRester(BaseRester[SummaryDoc]):
 
-    suffix = "summary"
+    suffix = "materials/summary"
     document_model = SummaryDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/surface_properties.py
+++ b/mp_api/client/routes/surface_properties.py
@@ -9,7 +9,7 @@ import warnings
 
 class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
 
-    suffix = "surface_properties"
+    suffix = "materials/surface_properties"
     document_model = SurfacePropDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/synthesis.py
+++ b/mp_api/client/routes/synthesis.py
@@ -11,7 +11,7 @@ import warnings
 
 
 class SynthesisRester(BaseRester[SynthesisSearchResultModel]):
-    suffix = "synthesis"
+    suffix = "materials/synthesis"
     document_model = SynthesisSearchResultModel  # type: ignore
 
     def search_synthesis_text(self, *args, **kwargs):  # pragma: no cover

--- a/mp_api/client/routes/tasks.py
+++ b/mp_api/client/routes/tasks.py
@@ -10,7 +10,7 @@ from mp_api.client.core.utils import validate_ids
 
 class TaskRester(BaseRester[TaskDoc]):
 
-    suffix = "tasks"
+    suffix = "materials/tasks"
     document_model = TaskDoc  # type: ignore
     primary_key = "task_id"
 
@@ -24,9 +24,9 @@ class TaskRester(BaseRester[TaskDoc]):
         :return: List of trajectory objects
         """
 
-        traj_data = self._query_resource_data(suburl=f"trajectory/{task_id}/", use_document_model=False)[0].get(
-            "trajectories", None
-        )
+        traj_data = self._query_resource_data(
+            suburl=f"trajectory/{task_id}/", use_document_model=False
+        )[0].get("trajectories", None)
 
         if traj_data is None:
             raise MPRestError(f"No trajectory data for {task_id} found")
@@ -39,7 +39,8 @@ class TaskRester(BaseRester[TaskDoc]):
         """
 
         warnings.warn(
-            "MPRester.tasks.search_task_docs is deprecated. " "Please use MPRester.tasks.search instead.",
+            "MPRester.tasks.search_task_docs is deprecated. "
+            "Please use MPRester.tasks.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -13,7 +13,7 @@ from mp_api.client.core.utils import validate_ids
 
 class ThermoRester(BaseRester[ThermoDoc]):
 
-    suffix = "thermo"
+    suffix = "materials/thermo"
     document_model = ThermoDoc  # type: ignore
     supports_versions = True
     primary_key = "thermo_id"
@@ -24,7 +24,8 @@ class ThermoRester(BaseRester[ThermoDoc]):
         """
 
         warnings.warn(
-            "MPRester.thermo.search_thermo_docs is deprecated. " "Please use MPRester.thermo.search instead.",
+            "MPRester.thermo.search_thermo_docs is deprecated. "
+            "Please use MPRester.thermo.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -108,19 +109,25 @@ class ThermoRester(BaseRester[ThermoDoc]):
             t_types = {t if isinstance(t, str) else t.value for t in thermo_types}
             valid_types = {*map(str, ThermoType.__members__.values())}
             if invalid_types := t_types - valid_types:
-                raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
+                raise ValueError(
+                    f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
+                )
             query_params.update({"thermo_types": ",".join(t_types)})
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
+            query_params.update(
+                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
+            )
 
         if is_stable is not None:
             query_params.update({"is_stable": is_stable})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
         name_dict = {
             "total_energy": "energy_per_atom",
@@ -139,7 +146,11 @@ class ThermoRester(BaseRester[ThermoDoc]):
                     }
                 )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,
@@ -166,7 +177,9 @@ class ThermoRester(BaseRester[ThermoDoc]):
         t_type = thermo_type if isinstance(thermo_type, str) else thermo_type.value
         valid_types = {*map(str, ThermoType.__members__.values())}
         if invalid_types := {t_type} - valid_types:
-            raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
+            raise ValueError(
+                f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
+            )
 
         sorted_chemsys = "-".join(sorted(chemsys.split("-")))
         phase_diagram_id = f"{sorted_chemsys}_{t_type}"

--- a/mp_api/client/routes/xas.py
+++ b/mp_api/client/routes/xas.py
@@ -10,7 +10,7 @@ import warnings
 
 class XASRester(BaseRester[XASDoc]):
 
-    suffix = "xas"
+    suffix = "materials/xas"
     document_model = XASDoc  # type: ignore
     primary_key = "spectrum_id"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,25 +5,25 @@ from mp_api.client import MPRester
 # -- Rester name data for generic tests
 
 key_only_resters = {
-    "phonon": "mp-11703",
-    "similarity": "mp-149",
+    "materials_phonon": "mp-11703",
+    "materials_similarity": "mp-149",
     "doi": "mp-149",
-    "wulff": "mp-149",
-    "charge_density": "mp-1936745",
-    "provenance": "mp-149",
-    "robocrys": "mp-1025395",
+    "materials_wulff": "mp-149",
+    "materials_charge_density": "mp-1936745",
+    "materials_provenance": "mp-149",
+    "materials_robocrys": "mp-1025395",
 }
 
 search_only_resters = [
-    "grain_boundary",
-    "electronic_structure_bandstructure",
-    "electronic_structure_dos",
-    "substrates",
-    "synthesis",
+    "materials_grain_boundary",
+    "materials_electronic_structure_bandstructure",
+    "materials_electronic_structure_dos",
+    "materials_substrates",
+    "materials_synthesis",
 ]
 
 special_resters = [
-    "charge_density",
+    "materials_charge_density",
 ]
 
 ignore_generic = [
@@ -31,9 +31,9 @@ ignore_generic = [
     "_general_store",
     # "tasks",
     # "bonds",
-    "xas",
-    "elasticity",
-    "fermi",
+    "materials_xas",
+    "materials_elasticity",
+    "materials_fermi",
     # "alloys",
     # "summary",
 ]  # temp
@@ -42,7 +42,9 @@ ignore_generic = [
 mpr = MPRester()
 
 
-@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
+@pytest.mark.skipif(
+    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
+)
 @pytest.mark.parametrize("rester", mpr._all_resters)
 def test_generic_get_methods(rester):
 
@@ -50,15 +52,21 @@ def test_generic_get_methods(rester):
     name = rester.suffix.replace("/", "_")
     if name not in ignore_generic:
         if name not in key_only_resters:
-            doc = rester._query_resource_data({"_limit": 1}, fields=[rester.primary_key])[0]
+            doc = rester._query_resource_data(
+                {"_limit": 1}, fields=[rester.primary_key]
+            )[0]
             assert isinstance(doc, rester.document_model)
 
             if name not in search_only_resters:
-                doc = rester.get_data_by_id(doc.dict()[rester.primary_key], fields=[rester.primary_key])
+                doc = rester.get_data_by_id(
+                    doc.dict()[rester.primary_key], fields=[rester.primary_key]
+                )
                 assert isinstance(doc, rester.document_model)
 
         elif name not in special_resters:
-            doc = rester.get_data_by_id(key_only_resters[name], fields=[rester.primary_key])
+            doc = rester.get_data_by_id(
+                key_only_resters[name], fields=[rester.primary_key]
+            )
             assert isinstance(doc, rester.document_model)
 
 

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -1,18 +1,13 @@
 import os
 import random
-import typing
 import numpy as np
 import itertools
 
 import pytest
-from emmet.core.summary import HasProps
-from emmet.core.symmetry import CrystalSystem
 from emmet.core.tasks import TaskDoc
 from emmet.core.vasp.calc_types import CalcType
-from sympy import prime
 from mp_api.client.core.settings import MAPIClientSettings
 from mp_api.client import MPRester
-from pymatgen.analysis.magnetism import Ordering
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry, PourbaixDiagram, PourbaixEntry
 from pymatgen.analysis.wulff import WulffShape


### PR DESCRIPTION
This PR adds support for nested `materials` endpoints in the API. A check has also been added to warn users if their current version is incompatible with the production service.