### PR TITLE
Add materials route nesting

### DIFF
--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -59,9 +59,7 @@ class MAPIClientSettings(BaseSettings):
         description="Number of parallel requests to send.",
     )
 
-    MAX_RETRIES: int = Field(
-        _MAX_RETRIES, description="Maximum number of retries for requests."
-    )
+    MAX_RETRIES: int = Field(_MAX_RETRIES, description="Maximum number of retries for requests.")
 
     BACKOFF_FACTOR: float = Field(
         0.1,
@@ -77,6 +75,13 @@ class MAPIClientSettings(BaseSettings):
         _MAX_HTTP_URL_LENGTH,
         description="Number of characters to use to define the maximum length of a given HTTP URL.",
     )
+
+    MAX_HTTP_URL_LENGTH: int = Field(
+        _MAX_HTTP_URL_LENGTH,
+        description="Number of characters to use to define the maximum length of a given HTTP URL.",
+    )
+
+    MIN_EMMET_VERSION: str = Field("0.54.0", description="Minimum compatible version of emmet-core for the client.")
 
     class Config:
         env_prefix = "MPRESTER_"

--- a/mp_api/client/core/settings.py
+++ b/mp_api/client/core/settings.py
@@ -59,7 +59,9 @@ class MAPIClientSettings(BaseSettings):
         description="Number of parallel requests to send.",
     )
 
-    MAX_RETRIES: int = Field(_MAX_RETRIES, description="Maximum number of retries for requests.")
+    MAX_RETRIES: int = Field(
+        _MAX_RETRIES, description="Maximum number of retries for requests."
+    )
 
     BACKOFF_FACTOR: float = Field(
         0.1,
@@ -81,7 +83,9 @@ class MAPIClientSettings(BaseSettings):
         description="Number of characters to use to define the maximum length of a given HTTP URL.",
     )
 
-    MIN_EMMET_VERSION: str = Field("0.54.0", description="Minimum compatible version of emmet-core for the client.")
+    MIN_EMMET_VERSION: str = Field(
+        "0.54.0", description="Minimum compatible version of emmet-core for the client."
+    )
 
     class Config:
         env_prefix = "MPRESTER_"

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -18,9 +18,11 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.vasp import Chgcar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from requests import Session, get
+from packaging import version
 
 from mp_api.client.core import BaseRester, MPRestError
 from mp_api.client.core.utils import validate_ids
+from mp_api.client.core.settings import MAPIClientSettings
 from mp_api.client.routes import (
     AbsorptionRester,
     AlloysRester,
@@ -64,6 +66,7 @@ _DEPRECATION_WARNING = (
 )
 
 _EMMET_SETTINGS = EmmetSettings()
+_MAPI_SETTINGS = MAPIClientSettings()
 
 DEFAULT_API_KEY = environ.get("MP_API_KEY", None)
 DEFAULT_ENDPOINT = environ.get("MP_API_ENDPOINT", "https://api.materialsproject.org/")
@@ -185,6 +188,15 @@ class MPRester:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")
 
+        # Check if emmet version of server os compatible
+        emmet_version = version.parse(self.get_emmet_version())
+
+        if version.parse(emmet_version.base_version) < version.parse(_MAPI_SETTINGS.MIN_EMMET_VERSION):
+            warnings.warn(
+                "The installed version of the mp-api client may not be compatible with the API server. "
+                "Please install a previous version if any problems occur."
+            )
+
         self._all_resters = []
 
         if notify_db_version:
@@ -208,11 +220,24 @@ class MPRester:
 
             self._all_resters.append(rester)
 
-            setattr(
-                self,
-                cls.suffix.replace("/", "_"),  # type: ignore
-                rester,
-            )
+            suffix_split = cls.suffix.split("/")
+
+            if len(suffix_split) == 1 or cls.suffix in [
+                "materials/core",
+                "molecules/core",
+            ]:
+                setattr(
+                    self,
+                    cls.suffix.split("/")[0],
+                    rester,
+                )
+
+            else:
+                setattr(
+                    self,
+                    "_".join(suffix_split[1:]),
+                    rester,
+                )
 
     def __enter__(self):
         """Support for "with" context."""
@@ -230,13 +255,10 @@ class MPRester:
             )
         elif attr == "charge_density":
             raise MPRestError(
-                "boto3 not installed. "
-                "To query charge density data first install with: 'pip install boto3'"
+                "boto3 not installed. " "To query charge density data first install with: 'pip install boto3'"
             )
         else:
-            raise AttributeError(
-                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
-            )
+            raise AttributeError(f"{self.__class__.__name__!r} object has no attribute {attr!r}")
 
     def get_task_ids_associated_with_material_id(
         self, material_id: str, calc_types: Optional[List[CalcType]] = None
@@ -245,13 +267,9 @@ class MPRester:
         :param calc_types: if specified, will restrict to certain task types, e.g. [CalcType.GGA_STATIC]
         :return:
         """
-        tasks = self.materials.get_data_by_id(
-            material_id, fields=["calc_types"]
-        ).calc_types
+        tasks = self.materials.get_data_by_id(material_id, fields=["calc_types"]).calc_types
         if calc_types:
-            return [
-                task for task, calc_type in tasks.items() if calc_type in calc_types
-            ]
+            return [task for task, calc_type in tasks.items() if calc_type in calc_types]
         else:
             return list(tasks.keys())
 
@@ -271,19 +289,14 @@ class MPRester:
         Returns:
             Structure object or list of Structure objects.
         """
-        structure_data = self.materials.get_structure_by_material_id(
-            material_id=material_id, final=final
-        )
+        structure_data = self.materials.get_structure_by_material_id(material_id=material_id, final=final)
 
         if conventional_unit_cell and structure_data:
             if final:
-                structure_data = SpacegroupAnalyzer(
-                    structure_data
-                ).get_conventional_standard_structure()
+                structure_data = SpacegroupAnalyzer(structure_data).get_conventional_standard_structure()
             else:
                 structure_data = [
-                    SpacegroupAnalyzer(structure).get_conventional_standard_structure()
-                    for structure in structure_data
+                    SpacegroupAnalyzer(structure).get_conventional_standard_structure() for structure in structure_data
                 ]
 
         return structure_data
@@ -303,6 +316,15 @@ class MPRester:
         """
         return get(url=self.endpoint + "heartbeat").json()["db_version"]
 
+    def get_emmet_version(self):
+        """
+        Get the latest version emmet-core and emmet-api used in the
+        current API service.
+
+        Returns: version as a string
+        """
+        return get(url=self.endpoint + "heartbeat").json()["version"]
+
     def get_material_id_from_task_id(self, task_id: str) -> Union[str, None]:
         """Returns the current material_id from a given task_id. The
         material_id should rarely change, and is usually chosen from
@@ -320,9 +342,7 @@ class MPRester:
         if len(docs) == 1:  # pragma: no cover
             return str(docs[0].material_id)  # type: ignore
         elif len(docs) > 1:  # pragma: no cover
-            raise ValueError(
-                f"Multiple documents return for {task_id}, this should not happen, please report it!"
-            )
+            raise ValueError(f"Multiple documents return for {task_id}, this should not happen, please report it!")
         else:  # pragma: no cover
             warnings.warn(
                 f"No material found containing task {task_id}. Please report it if you suspect a task has gone missing."
@@ -369,9 +389,7 @@ class MPRester:
         Returns:
             List of all materials ids ([MPID])
         """
-        if isinstance(chemsys_formula, list) or (
-            isinstance(chemsys_formula, str) and "-" in chemsys_formula
-        ):
+        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -396,9 +414,7 @@ class MPRester:
         )
         return self.get_material_ids(chemsys_formula)
 
-    def get_structures(
-        self, chemsys_formula: Union[str, List[str]], final=True
-    ) -> List[Structure]:
+    def get_structures(self, chemsys_formula: Union[str, List[str]], final=True) -> List[Structure]:
         """Get a list of Structures corresponding to a chemical system or formula.
 
         Args:
@@ -410,9 +426,7 @@ class MPRester:
         Returns:
             List of Structure objects. ([Structure])
         """
-        if isinstance(chemsys_formula, list) or (
-            isinstance(chemsys_formula, str) and "-" in chemsys_formula
-        ):
+        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -561,11 +575,7 @@ class MPRester:
             )
 
         for doc in docs:
-            entry_list = (
-                doc.entries.values()
-                if self.use_document_model
-                else doc["entries"].values()
-            )
+            entry_list = doc.entries.values() if self.use_document_model else doc["entries"].values()
             for entry in entry_list:
                 entry_dict = entry.as_dict() if self.monty_decode else entry
                 if not compatible_only:
@@ -575,16 +585,12 @@ class MPRester:
                 if property_data:
                     for property in property_data:
                         entry_dict["data"][property] = (
-                            doc.dict()[property]
-                            if self.use_document_model
-                            else doc[property]
+                            doc.dict()[property] if self.use_document_model else doc[property]
                         )
 
                 if conventional_unit_cell:
                     entry_struct = Structure.from_dict(entry_dict["structure"])
-                    s = SpacegroupAnalyzer(
-                        entry_struct
-                    ).get_conventional_standard_structure()
+                    s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
                     new_energy = entry_dict["energy"] * site_ratio
 
@@ -599,11 +605,7 @@ class MPRester:
                         if "n_atoms" in correction:
                             correction["n_atoms"] *= site_ratio
 
-                entry = (
-                    ComputedStructureEntry.from_dict(entry_dict)
-                    if self.monty_decode
-                    else entry_dict
-                )
+                entry = ComputedStructureEntry.from_dict(entry_dict) if self.monty_decode else entry_dict
 
                 entries.append(entry)
 
@@ -670,12 +672,8 @@ class MPRester:
         ion_data = self.get_ion_reference_data_for_chemsys(chemsys)
 
         # build the PhaseDiagram for get_ion_entries
-        ion_ref_comps = [
-            Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data
-        ]
-        ion_ref_elts = set(
-            itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
-        )
+        ion_ref_comps = [Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data]
+        ion_ref_elts = set(itertools.chain.from_iterable(i.elements for i in ion_ref_comps))
         # TODO - would be great if the commented line below would work
         # However for some reason you cannot process GibbsComputedStructureEntry with
         # MaterialsProjectAqueousCompatibility
@@ -694,9 +692,7 @@ class MPRester:
             compat = MaterialsProjectAqueousCompatibility(solid_compat=solid_compat)
         # suppress the warning about missing oxidation states
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="Failed to guess oxidation states.*"
-            )
+            warnings.filterwarnings("ignore", message="Failed to guess oxidation states.*")
             ion_ref_entries = compat.process_entries(ion_ref_entries)
         # TODO - if the commented line above would work, this conditional block
         # could be removed
@@ -704,32 +700,21 @@ class MPRester:
             # replace the entries with GibbsComputedStructureEntry
             from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
-            ion_ref_entries = GibbsComputedStructureEntry.from_entries(
-                ion_ref_entries, temp=use_gibbs
-            )
+            ion_ref_entries = GibbsComputedStructureEntry.from_entries(ion_ref_entries, temp=use_gibbs)
         ion_ref_pd = PhaseDiagram(ion_ref_entries)
 
         ion_entries = self.get_ion_entries(ion_ref_pd, ion_ref_data=ion_data)
         pbx_entries = [PourbaixEntry(e, f"ion-{n}") for n, e in enumerate(ion_entries)]
 
         # Construct the solid pourbaix entries from filtered ion_ref entries
-        extra_elts = (
-            set(ion_ref_elts)
-            - {Element(s) for s in chemsys}
-            - {Element("H"), Element("O")}
-        )
+        extra_elts = set(ion_ref_elts) - {Element(s) for s in chemsys} - {Element("H"), Element("O")}
         for entry in ion_ref_entries:
             entry_elts = set(entry.composition.elements)
             # Ensure no OH chemsys or extraneous elements from ion references
-            if not (
-                entry_elts <= {Element("H"), Element("O")}
-                or extra_elts.intersection(entry_elts)
-            ):
+            if not (entry_elts <= {Element("H"), Element("O")} or extra_elts.intersection(entry_elts)):
                 # Create new computed entry
                 form_e = ion_ref_pd.get_form_energy(entry)
-                new_entry = ComputedEntry(
-                    entry.composition, form_e, entry_id=entry.entry_id
-                )
+                new_entry = ComputedEntry(entry.composition, form_e, entry_id=entry.entry_id)
                 pbx_entry = PourbaixEntry(new_entry)
                 pbx_entries.append(pbx_entry)
 
@@ -770,9 +755,7 @@ class MPRester:
             paginate=True,
         ).get("data")
 
-    def get_ion_reference_data_for_chemsys(
-        self, chemsys: Union[str, List]
-    ) -> List[Dict]:
+    def get_ion_reference_data_for_chemsys(self, chemsys: Union[str, List]) -> List[Dict]:
         """Download aqueous ion reference data used in the construction of Pourbaix diagrams.
 
         Use this method to examine the ion reference data and to add additional
@@ -809,9 +792,7 @@ class MPRester:
 
         return [d for d in ion_data if d["data"]["MajElements"] in chemsys]
 
-    def get_ion_entries(
-        self, pd: PhaseDiagram, ion_ref_data: List[dict] = None
-    ) -> List[IonEntry]:
+    def get_ion_entries(self, pd: PhaseDiagram, ion_ref_data: List[dict] = None) -> List[IonEntry]:
         """Retrieve IonEntry objects that can be used in the construction of
         Pourbaix Diagrams. The energies of the IonEntry are calculaterd from
         the solid energies in the provided Phase Diagram to be
@@ -844,8 +825,7 @@ class MPRester:
         # raise ValueError if O and H not in chemsys
         if "O" not in chemsys or "H" not in chemsys:
             raise ValueError(
-                "The phase diagram chemical system must contain O and H! Your"
-                f" diagram chemical system is {chemsys}."
+                "The phase diagram chemical system must contain O and H! Your" f" diagram chemical system is {chemsys}."
             )
 
         if not ion_ref_data:
@@ -857,11 +837,7 @@ class MPRester:
         ion_entries = []
         for _n, i_d in enumerate(ion_data):
             ion = Ion.from_formula(i_d["formula"])
-            refs = [
-                e
-                for e in pd.all_entries
-                if e.composition.reduced_formula == i_d["data"]["RefSolid"]
-            ]
+            refs = [e for e in pd.all_entries if e.composition.reduced_formula == i_d["data"]["RefSolid"]]
             if not refs:
                 raise ValueError("Reference solid not contained in entry list")
             stable_ref = sorted(refs, key=lambda x: x.energy_per_atom)[0]
@@ -876,9 +852,7 @@ class MPRester:
                 # convert to eV/formula unit
                 ref_solid_energy = i_d["data"]["ΔGᶠRefSolid"]["value"] / 96485
             else:
-                raise ValueError(
-                    f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}"
-                )
+                raise ValueError(f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}")
             solid_diff = pd.get_form_energy(stable_ref) - ref_solid_energy * rf
             elt = i_d["data"]["MajElements"]
             correction_factor = ion.composition[elt] / stable_ref.composition[elt]
@@ -891,9 +865,7 @@ class MPRester:
                 # convert to eV/formula unit
                 ion_free_energy = i_d["data"]["ΔGᶠ"]["value"] / 96485
             else:
-                raise ValueError(
-                    f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}"
-                )
+                raise ValueError(f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}")
             energy = ion_free_energy + solid_diff * correction_factor
             ion_entries.append(IonEntry(ion, energy))
 
@@ -1012,8 +984,7 @@ class MPRester:
                 inc_structure=inc_structure,
                 property_data=property_data,
                 conventional_unit_cell=conventional_unit_cell,
-                additional_criteria=additional_criteria
-                or {"thermo_types": ["GGA_GGA+U"]},
+                additional_criteria=additional_criteria or {"thermo_types": ["GGA_GGA+U"]},
             )
         )
 
@@ -1115,12 +1086,8 @@ class MPRester:
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
         structure = self.get_structure_by_material_id(material_id)
-        surfaces = surfaces = self.surface_properties.get_data_by_id(
-            material_id
-        ).surfaces
-        lattice = (
-            SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
-        )
+        surfaces = surfaces = self.surface_properties.get_data_by_id(material_id).surfaces
+        lattice = SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
         miller_energy_map = {}
         for surf in surfaces:
             miller = tuple(surf.miller_index)
@@ -1130,9 +1097,7 @@ class MPRester:
         millers, energies = zip(*miller_energy_map.items())
         return WulffShape(lattice, millers, energies)
 
-    def get_charge_density_from_material_id(
-        self, material_id: str, inc_task_doc: bool = False
-    ) -> Optional[Chgcar]:
+    def get_charge_density_from_material_id(self, material_id: str, inc_task_doc: bool = False) -> Optional[Chgcar]:
         """Get charge density data for a given Materials Project ID.
 
         Arguments:
@@ -1143,10 +1108,7 @@ class MPRester:
             chgcar: Pymatgen Chgcar object.
         """
         if not hasattr(self, "charge_density"):
-            raise MPRestError(
-                "boto3 not installed. "
-                "To query charge density data install the boto3 package."
-            )
+            raise MPRestError("boto3 not installed. " "To query charge density data install the boto3 package.")
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity
@@ -1184,11 +1146,7 @@ class MPRester:
             metadata info, e.g. the task/external_ids that belong to a directory.
         """
         # task_id's correspond to NoMaD external_id's
-        calc_types = (
-            [t.value for t in calc_types if isinstance(t, CalcType)]
-            if calc_types
-            else []
-        )
+        calc_types = [t.value for t in calc_types if isinstance(t, CalcType)] if calc_types else []
 
         meta = {}
         for doc in self.materials.search(
@@ -1218,13 +1176,9 @@ class MPRester:
         prefix += "external_id="
 
         task_ids = [t["task_id"] for tl in meta.values() for t in tl]
-        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(
-            prefix=prefix, task_ids=task_ids
-        )
+        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(prefix=prefix, task_ids=task_ids)
         if len(nomad_exist_task_ids) != len(task_ids):
-            self._print_help_message(
-                nomad_exist_task_ids, task_ids, file_patterns, calc_types
-            )
+            self._print_help_message(nomad_exist_task_ids, task_ids, file_patterns, calc_types)
 
         # generate download links for those that exist
         prefix = "https://nomad-lab.eu/prod/rae/api/raw/query?"

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -10,6 +10,7 @@ from emmet.core.electronic_structure import BSPathType
 from emmet.core.mpid import MPID
 from emmet.core.settings import EmmetSettings
 from emmet.core.vasp.calc_types import CalcType
+from packaging import version
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry
 from pymatgen.core import Element, Structure
@@ -18,11 +19,10 @@ from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.vasp import Chgcar
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from requests import Session, get
-from packaging import version
 
 from mp_api.client.core import BaseRester, MPRestError
-from mp_api.client.core.utils import validate_ids
 from mp_api.client.core.settings import MAPIClientSettings
+from mp_api.client.core.utils import validate_ids
 from mp_api.client.routes import (
     AbsorptionRester,
     AlloysRester,
@@ -191,7 +191,9 @@ class MPRester:
         # Check if emmet version of server os compatible
         emmet_version = version.parse(self.get_emmet_version())
 
-        if version.parse(emmet_version.base_version) < version.parse(_MAPI_SETTINGS.MIN_EMMET_VERSION):
+        if version.parse(emmet_version.base_version) < version.parse(
+            _MAPI_SETTINGS.MIN_EMMET_VERSION
+        ):
             warnings.warn(
                 "The installed version of the mp-api client may not be compatible with the API server. "
                 "Please install a previous version if any problems occur."
@@ -255,10 +257,13 @@ class MPRester:
             )
         elif attr == "charge_density":
             raise MPRestError(
-                "boto3 not installed. " "To query charge density data first install with: 'pip install boto3'"
+                "boto3 not installed. "
+                "To query charge density data first install with: 'pip install boto3'"
             )
         else:
-            raise AttributeError(f"{self.__class__.__name__!r} object has no attribute {attr!r}")
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
+            )
 
     def get_task_ids_associated_with_material_id(
         self, material_id: str, calc_types: Optional[List[CalcType]] = None
@@ -267,9 +272,13 @@ class MPRester:
         :param calc_types: if specified, will restrict to certain task types, e.g. [CalcType.GGA_STATIC]
         :return:
         """
-        tasks = self.materials.get_data_by_id(material_id, fields=["calc_types"]).calc_types
+        tasks = self.materials.get_data_by_id(
+            material_id, fields=["calc_types"]
+        ).calc_types
         if calc_types:
-            return [task for task, calc_type in tasks.items() if calc_type in calc_types]
+            return [
+                task for task, calc_type in tasks.items() if calc_type in calc_types
+            ]
         else:
             return list(tasks.keys())
 
@@ -289,14 +298,19 @@ class MPRester:
         Returns:
             Structure object or list of Structure objects.
         """
-        structure_data = self.materials.get_structure_by_material_id(material_id=material_id, final=final)
+        structure_data = self.materials.get_structure_by_material_id(
+            material_id=material_id, final=final
+        )
 
         if conventional_unit_cell and structure_data:
             if final:
-                structure_data = SpacegroupAnalyzer(structure_data).get_conventional_standard_structure()
+                structure_data = SpacegroupAnalyzer(
+                    structure_data
+                ).get_conventional_standard_structure()
             else:
                 structure_data = [
-                    SpacegroupAnalyzer(structure).get_conventional_standard_structure() for structure in structure_data
+                    SpacegroupAnalyzer(structure).get_conventional_standard_structure()
+                    for structure in structure_data
                 ]
 
         return structure_data
@@ -342,7 +356,9 @@ class MPRester:
         if len(docs) == 1:  # pragma: no cover
             return str(docs[0].material_id)  # type: ignore
         elif len(docs) > 1:  # pragma: no cover
-            raise ValueError(f"Multiple documents return for {task_id}, this should not happen, please report it!")
+            raise ValueError(
+                f"Multiple documents return for {task_id}, this should not happen, please report it!"
+            )
         else:  # pragma: no cover
             warnings.warn(
                 f"No material found containing task {task_id}. Please report it if you suspect a task has gone missing."
@@ -389,7 +405,9 @@ class MPRester:
         Returns:
             List of all materials ids ([MPID])
         """
-        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
+        if isinstance(chemsys_formula, list) or (
+            isinstance(chemsys_formula, str) and "-" in chemsys_formula
+        ):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -414,7 +432,9 @@ class MPRester:
         )
         return self.get_material_ids(chemsys_formula)
 
-    def get_structures(self, chemsys_formula: Union[str, List[str]], final=True) -> List[Structure]:
+    def get_structures(
+        self, chemsys_formula: Union[str, List[str]], final=True
+    ) -> List[Structure]:
         """Get a list of Structures corresponding to a chemical system or formula.
 
         Args:
@@ -426,7 +446,9 @@ class MPRester:
         Returns:
             List of Structure objects. ([Structure])
         """
-        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
+        if isinstance(chemsys_formula, list) or (
+            isinstance(chemsys_formula, str) and "-" in chemsys_formula
+        ):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -575,7 +597,11 @@ class MPRester:
             )
 
         for doc in docs:
-            entry_list = doc.entries.values() if self.use_document_model else doc["entries"].values()
+            entry_list = (
+                doc.entries.values()
+                if self.use_document_model
+                else doc["entries"].values()
+            )
             for entry in entry_list:
                 entry_dict = entry.as_dict() if self.monty_decode else entry
                 if not compatible_only:
@@ -585,12 +611,16 @@ class MPRester:
                 if property_data:
                     for property in property_data:
                         entry_dict["data"][property] = (
-                            doc.dict()[property] if self.use_document_model else doc[property]
+                            doc.dict()[property]
+                            if self.use_document_model
+                            else doc[property]
                         )
 
                 if conventional_unit_cell:
                     entry_struct = Structure.from_dict(entry_dict["structure"])
-                    s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
+                    s = SpacegroupAnalyzer(
+                        entry_struct
+                    ).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
                     new_energy = entry_dict["energy"] * site_ratio
 
@@ -605,7 +635,11 @@ class MPRester:
                         if "n_atoms" in correction:
                             correction["n_atoms"] *= site_ratio
 
-                entry = ComputedStructureEntry.from_dict(entry_dict) if self.monty_decode else entry_dict
+                entry = (
+                    ComputedStructureEntry.from_dict(entry_dict)
+                    if self.monty_decode
+                    else entry_dict
+                )
 
                 entries.append(entry)
 
@@ -672,8 +706,12 @@ class MPRester:
         ion_data = self.get_ion_reference_data_for_chemsys(chemsys)
 
         # build the PhaseDiagram for get_ion_entries
-        ion_ref_comps = [Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data]
-        ion_ref_elts = set(itertools.chain.from_iterable(i.elements for i in ion_ref_comps))
+        ion_ref_comps = [
+            Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data
+        ]
+        ion_ref_elts = set(
+            itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
+        )
         # TODO - would be great if the commented line below would work
         # However for some reason you cannot process GibbsComputedStructureEntry with
         # MaterialsProjectAqueousCompatibility
@@ -692,7 +730,9 @@ class MPRester:
             compat = MaterialsProjectAqueousCompatibility(solid_compat=solid_compat)
         # suppress the warning about missing oxidation states
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Failed to guess oxidation states.*")
+            warnings.filterwarnings(
+                "ignore", message="Failed to guess oxidation states.*"
+            )
             ion_ref_entries = compat.process_entries(ion_ref_entries)
         # TODO - if the commented line above would work, this conditional block
         # could be removed
@@ -700,21 +740,32 @@ class MPRester:
             # replace the entries with GibbsComputedStructureEntry
             from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
-            ion_ref_entries = GibbsComputedStructureEntry.from_entries(ion_ref_entries, temp=use_gibbs)
+            ion_ref_entries = GibbsComputedStructureEntry.from_entries(
+                ion_ref_entries, temp=use_gibbs
+            )
         ion_ref_pd = PhaseDiagram(ion_ref_entries)
 
         ion_entries = self.get_ion_entries(ion_ref_pd, ion_ref_data=ion_data)
         pbx_entries = [PourbaixEntry(e, f"ion-{n}") for n, e in enumerate(ion_entries)]
 
         # Construct the solid pourbaix entries from filtered ion_ref entries
-        extra_elts = set(ion_ref_elts) - {Element(s) for s in chemsys} - {Element("H"), Element("O")}
+        extra_elts = (
+            set(ion_ref_elts)
+            - {Element(s) for s in chemsys}
+            - {Element("H"), Element("O")}
+        )
         for entry in ion_ref_entries:
             entry_elts = set(entry.composition.elements)
             # Ensure no OH chemsys or extraneous elements from ion references
-            if not (entry_elts <= {Element("H"), Element("O")} or extra_elts.intersection(entry_elts)):
+            if not (
+                entry_elts <= {Element("H"), Element("O")}
+                or extra_elts.intersection(entry_elts)
+            ):
                 # Create new computed entry
                 form_e = ion_ref_pd.get_form_energy(entry)
-                new_entry = ComputedEntry(entry.composition, form_e, entry_id=entry.entry_id)
+                new_entry = ComputedEntry(
+                    entry.composition, form_e, entry_id=entry.entry_id
+                )
                 pbx_entry = PourbaixEntry(new_entry)
                 pbx_entries.append(pbx_entry)
 
@@ -755,7 +806,9 @@ class MPRester:
             paginate=True,
         ).get("data")
 
-    def get_ion_reference_data_for_chemsys(self, chemsys: Union[str, List]) -> List[Dict]:
+    def get_ion_reference_data_for_chemsys(
+        self, chemsys: Union[str, List]
+    ) -> List[Dict]:
         """Download aqueous ion reference data used in the construction of Pourbaix diagrams.
 
         Use this method to examine the ion reference data and to add additional
@@ -792,7 +845,9 @@ class MPRester:
 
         return [d for d in ion_data if d["data"]["MajElements"] in chemsys]
 
-    def get_ion_entries(self, pd: PhaseDiagram, ion_ref_data: List[dict] = None) -> List[IonEntry]:
+    def get_ion_entries(
+        self, pd: PhaseDiagram, ion_ref_data: List[dict] = None
+    ) -> List[IonEntry]:
         """Retrieve IonEntry objects that can be used in the construction of
         Pourbaix Diagrams. The energies of the IonEntry are calculaterd from
         the solid energies in the provided Phase Diagram to be
@@ -825,7 +880,8 @@ class MPRester:
         # raise ValueError if O and H not in chemsys
         if "O" not in chemsys or "H" not in chemsys:
             raise ValueError(
-                "The phase diagram chemical system must contain O and H! Your" f" diagram chemical system is {chemsys}."
+                "The phase diagram chemical system must contain O and H! Your"
+                f" diagram chemical system is {chemsys}."
             )
 
         if not ion_ref_data:
@@ -837,7 +893,11 @@ class MPRester:
         ion_entries = []
         for _n, i_d in enumerate(ion_data):
             ion = Ion.from_formula(i_d["formula"])
-            refs = [e for e in pd.all_entries if e.composition.reduced_formula == i_d["data"]["RefSolid"]]
+            refs = [
+                e
+                for e in pd.all_entries
+                if e.composition.reduced_formula == i_d["data"]["RefSolid"]
+            ]
             if not refs:
                 raise ValueError("Reference solid not contained in entry list")
             stable_ref = sorted(refs, key=lambda x: x.energy_per_atom)[0]
@@ -852,7 +912,9 @@ class MPRester:
                 # convert to eV/formula unit
                 ref_solid_energy = i_d["data"]["ΔGᶠRefSolid"]["value"] / 96485
             else:
-                raise ValueError(f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}")
+                raise ValueError(
+                    f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}"
+                )
             solid_diff = pd.get_form_energy(stable_ref) - ref_solid_energy * rf
             elt = i_d["data"]["MajElements"]
             correction_factor = ion.composition[elt] / stable_ref.composition[elt]
@@ -865,7 +927,9 @@ class MPRester:
                 # convert to eV/formula unit
                 ion_free_energy = i_d["data"]["ΔGᶠ"]["value"] / 96485
             else:
-                raise ValueError(f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}")
+                raise ValueError(
+                    f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}"
+                )
             energy = ion_free_energy + solid_diff * correction_factor
             ion_entries.append(IonEntry(ion, energy))
 
@@ -984,7 +1048,8 @@ class MPRester:
                 inc_structure=inc_structure,
                 property_data=property_data,
                 conventional_unit_cell=conventional_unit_cell,
-                additional_criteria=additional_criteria or {"thermo_types": ["GGA_GGA+U"]},
+                additional_criteria=additional_criteria
+                or {"thermo_types": ["GGA_GGA+U"]},
             )
         )
 
@@ -1086,8 +1151,12 @@ class MPRester:
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
         structure = self.get_structure_by_material_id(material_id)
-        surfaces = surfaces = self.surface_properties.get_data_by_id(material_id).surfaces
-        lattice = SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
+        surfaces = surfaces = self.surface_properties.get_data_by_id(
+            material_id
+        ).surfaces
+        lattice = (
+            SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
+        )
         miller_energy_map = {}
         for surf in surfaces:
             miller = tuple(surf.miller_index)
@@ -1097,7 +1166,9 @@ class MPRester:
         millers, energies = zip(*miller_energy_map.items())
         return WulffShape(lattice, millers, energies)
 
-    def get_charge_density_from_material_id(self, material_id: str, inc_task_doc: bool = False) -> Optional[Chgcar]:
+    def get_charge_density_from_material_id(
+        self, material_id: str, inc_task_doc: bool = False
+    ) -> Optional[Chgcar]:
         """Get charge density data for a given Materials Project ID.
 
         Arguments:
@@ -1108,7 +1179,10 @@ class MPRester:
             chgcar: Pymatgen Chgcar object.
         """
         if not hasattr(self, "charge_density"):
-            raise MPRestError("boto3 not installed. " "To query charge density data install the boto3 package.")
+            raise MPRestError(
+                "boto3 not installed. "
+                "To query charge density data install the boto3 package."
+            )
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity
@@ -1146,7 +1220,11 @@ class MPRester:
             metadata info, e.g. the task/external_ids that belong to a directory.
         """
         # task_id's correspond to NoMaD external_id's
-        calc_types = [t.value for t in calc_types if isinstance(t, CalcType)] if calc_types else []
+        calc_types = (
+            [t.value for t in calc_types if isinstance(t, CalcType)]
+            if calc_types
+            else []
+        )
 
         meta = {}
         for doc in self.materials.search(
@@ -1176,9 +1254,13 @@ class MPRester:
         prefix += "external_id="
 
         task_ids = [t["task_id"] for tl in meta.values() for t in tl]
-        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(prefix=prefix, task_ids=task_ids)
+        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(
+            prefix=prefix, task_ids=task_ids
+        )
         if len(nomad_exist_task_ids) != len(task_ids):
-            self._print_help_message(nomad_exist_task_ids, task_ids, file_patterns, calc_types)
+            self._print_help_message(
+                nomad_exist_task_ids, task_ids, file_patterns, calc_types
+            )
 
         # generate download links for those that exist
         prefix = "https://nomad-lab.eu/prod/rae/api/raw/query?"

--- a/mp_api/client/routes/absorption.py
+++ b/mp_api/client/routes/absorption.py
@@ -8,7 +8,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class AbsorptionRester(BaseRester[AbsorptionDoc]):
-    suffix = "absorption"
+    suffix = "materials/absorption"
     document_model = AbsorptionDoc  # type: ignore
     primary_key = "material_id"
 
@@ -72,15 +72,9 @@ class AbsorptionRester(BaseRester[AbsorptionDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             formulae=formula,

--- a/mp_api/client/routes/absorption.py
+++ b/mp_api/client/routes/absorption.py
@@ -72,9 +72,15 @@ class AbsorptionRester(BaseRester[AbsorptionDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             formulae=formula,

--- a/mp_api/client/routes/alloys.py
+++ b/mp_api/client/routes/alloys.py
@@ -43,7 +43,11 @@ class AlloysRester(BaseRester[AlloyPairDoc]):
         """
         query_params = defaultdict(dict)  # type: dict
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         if material_ids:
             if isinstance(material_ids, str):
@@ -52,7 +56,9 @@ class AlloysRester(BaseRester[AlloyPairDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
         return super()._search(
             formulae=formulae,

--- a/mp_api/client/routes/alloys.py
+++ b/mp_api/client/routes/alloys.py
@@ -8,7 +8,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class AlloysRester(BaseRester[AlloyPairDoc]):
-    suffix = "alloys"
+    suffix = "materials/alloys"
     document_model = AlloyPairDoc  # type: ignore
     primary_key = "pair_id"
 
@@ -43,11 +43,7 @@ class AlloysRester(BaseRester[AlloyPairDoc]):
         """
         query_params = defaultdict(dict)  # type: dict
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         if material_ids:
             if isinstance(material_ids, str):
@@ -56,9 +52,7 @@ class AlloysRester(BaseRester[AlloyPairDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
         return super()._search(
             formulae=formulae,

--- a/mp_api/client/routes/bonds.py
+++ b/mp_api/client/routes/bonds.py
@@ -9,7 +9,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class BondsRester(BaseRester[BondingDoc]):
-    suffix = "bonds"
+    suffix = "materials/bonds"
     document_model = BondingDoc  # type: ignore
     primary_key = "material_id"
 
@@ -96,25 +96,13 @@ class BondsRester(BaseRester[BondingDoc]):
             query_params.update({"coordination_envs": ",".join(coordination_envs)})
 
         if coordination_envs_anonymous is not None:
-            query_params.update(
-                {"coordination_envs_anonymous": ",".join(coordination_envs_anonymous)}
-            )
+            query_params.update({"coordination_envs_anonymous": ",".join(coordination_envs_anonymous)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/bonds.py
+++ b/mp_api/client/routes/bonds.py
@@ -96,13 +96,25 @@ class BondsRester(BaseRester[BondingDoc]):
             query_params.update({"coordination_envs": ",".join(coordination_envs)})
 
         if coordination_envs_anonymous is not None:
-            query_params.update({"coordination_envs_anonymous": ",".join(coordination_envs_anonymous)})
+            query_params.update(
+                {"coordination_envs_anonymous": ",".join(coordination_envs_anonymous)}
+            )
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/charge_density.py
+++ b/mp_api/client/routes/charge_density.py
@@ -16,7 +16,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
-    suffix = "charge_density"
+    suffix = "materials/charge_density"
     primary_key = "fs_id"
     document_model = ChgcarDataDoc  # type: ignore
     boto_resource = None
@@ -87,9 +87,7 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
             # from public MinIO buckets.
             if environ.get("AWS_EXECUTION_ENV", None) == "AWS_ECS_FARGATE":
                 if self.boto_resource is None:
-                    self.boto_resource = self._get_s3_resource(
-                        use_minio=False, unsigned=False
-                    )
+                    self.boto_resource = self._get_s3_resource(use_minio=False, unsigned=False)
 
                 bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
 
@@ -103,9 +101,7 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
                 except ConnectionError:
                     self.boto_resource = self._get_s3_resource(use_minio=False)
 
-                    bucket, obj_prefix = self._extract_s3_url_info(
-                        url_doc, use_minio=False
-                    )
+                    bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
 
             r = self.boto_resource.Object(bucket, f"{obj_prefix}/{url_doc.fs_id}").get()["Body"]  # type: ignore
 

--- a/mp_api/client/routes/charge_density.py
+++ b/mp_api/client/routes/charge_density.py
@@ -87,7 +87,9 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
             # from public MinIO buckets.
             if environ.get("AWS_EXECUTION_ENV", None) == "AWS_ECS_FARGATE":
                 if self.boto_resource is None:
-                    self.boto_resource = self._get_s3_resource(use_minio=False, unsigned=False)
+                    self.boto_resource = self._get_s3_resource(
+                        use_minio=False, unsigned=False
+                    )
 
                 bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
 
@@ -101,7 +103,9 @@ class ChargeDensityRester(BaseRester[ChgcarDataDoc]):
                 except ConnectionError:
                     self.boto_resource = self._get_s3_resource(use_minio=False)
 
-                    bucket, obj_prefix = self._extract_s3_url_info(url_doc, use_minio=False)
+                    bucket, obj_prefix = self._extract_s3_url_info(
+                        url_doc, use_minio=False
+                    )
 
             r = self.boto_resource.Object(bucket, f"{obj_prefix}/{url_doc.fs_id}").get()["Body"]  # type: ignore
 

--- a/mp_api/client/routes/chemenv.py
+++ b/mp_api/client/routes/chemenv.py
@@ -8,7 +8,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ChemenvRester(BaseRester[ChemEnvDoc]):
-    suffix = "chemenv"
+    suffix = "materials/chemenv"
     document_model = ChemEnvDoc  # type: ignore
     primary_key = "material_id"
 
@@ -62,16 +62,12 @@ class ChemenvRester(BaseRester[ChemEnvDoc]):
             query_params.update({"density_min": density[0], "density_max": density[1]})
 
         if num_sites:
-            query_params.update(
-                {"nsites_min": num_sites[0], "nsites_max": num_sites[1]}
-            )
+            query_params.update({"nsites_min": num_sites[0], "nsites_max": num_sites[1]})
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if material_ids:
             if isinstance(material_ids, str):
@@ -98,20 +94,10 @@ class ChemenvRester(BaseRester[ChemEnvDoc]):
             query_params.update({"chemenv_name": ",".join(chemenv_name)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/chemenv.py
+++ b/mp_api/client/routes/chemenv.py
@@ -62,12 +62,16 @@ class ChemenvRester(BaseRester[ChemEnvDoc]):
             query_params.update({"density_min": density[0], "density_max": density[1]})
 
         if num_sites:
-            query_params.update({"nsites_min": num_sites[0], "nsites_max": num_sites[1]})
+            query_params.update(
+                {"nsites_min": num_sites[0], "nsites_max": num_sites[1]}
+            )
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
+            query_params.update(
+                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
+            )
 
         if material_ids:
             if isinstance(material_ids, str):
@@ -94,10 +98,20 @@ class ChemenvRester(BaseRester[ChemEnvDoc]):
             query_params.update({"chemenv_name": ",".join(chemenv_name)})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/dielectric.py
+++ b/mp_api/client/routes/dielectric.py
@@ -9,7 +9,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class DielectricRester(BaseRester[DielectricDoc]):
-    suffix = "dielectric"
+    suffix = "materials/dielectric"
     document_model = DielectricDoc  # type: ignore
     primary_key = "material_id"
 
@@ -81,20 +81,10 @@ class DielectricRester(BaseRester[DielectricDoc]):
             query_params.update({"n_min": n[0], "n_max": n[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/dielectric.py
+++ b/mp_api/client/routes/dielectric.py
@@ -81,10 +81,20 @@ class DielectricRester(BaseRester[DielectricDoc]):
             query_params.update({"n_min": n[0], "n_max": n[1]})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/elasticity.py
+++ b/mp_api/client/routes/elasticity.py
@@ -96,13 +96,25 @@ class ElasticityRester(BaseRester[ElasticityDoc]):
             )
 
         if poisson_ratio:
-            query_params.update({"poisson_min": poisson_ratio[0], "poisson_max": poisson_ratio[1]})
+            query_params.update(
+                {"poisson_min": poisson_ratio[0], "poisson_max": poisson_ratio[1]}
+            )
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/elasticity.py
+++ b/mp_api/client/routes/elasticity.py
@@ -8,7 +8,7 @@ from mp_api.client.core import BaseRester
 
 
 class ElasticityRester(BaseRester[ElasticityDoc]):
-    suffix = "elasticity"
+    suffix = "materials/elasticity"
     document_model = ElasticityDoc  # type: ignore
     primary_key = "task_id"
 
@@ -96,25 +96,13 @@ class ElasticityRester(BaseRester[ElasticityDoc]):
             )
 
         if poisson_ratio:
-            query_params.update(
-                {"poisson_min": poisson_ratio[0], "poisson_max": poisson_ratio[1]}
-            )
+            query_params.update({"poisson_min": poisson_ratio[0], "poisson_max": poisson_ratio[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/electrodes.py
+++ b/mp_api/client/routes/electrodes.py
@@ -10,7 +10,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
-    suffix = "insertion_electrodes"
+    suffix = "materials/insertion_electrodes"
     document_model = InsertionElectrodeDoc  # type: ignore
     primary_key = "battery_id"
 
@@ -113,9 +113,7 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
             if isinstance(working_ion, (str, Element)):
                 working_ion = [working_ion]  # type: ignore
 
-            query_params.update(
-                {"working_ion": ",".join([str(ele) for ele in working_ion])}  # type: ignore
-            )
+            query_params.update({"working_ion": ",".join([str(ele) for ele in working_ion])})  # type: ignore
 
         if formula:
             if isinstance(formula, str):
@@ -129,17 +127,13 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if exclude_elements:
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
         for param, value in locals().items():
             if (
@@ -154,16 +148,10 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
                 and value
             ):
                 if isinstance(value, tuple):
-                    query_params.update(
-                        {f"{param}_min": value[0], f"{param}_max": value[1]}
-                    )
+                    query_params.update({f"{param}_min": value[0], f"{param}_max": value[1]})
                 else:
                     query_params.update({param: value})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(**query_params)

--- a/mp_api/client/routes/electrodes.py
+++ b/mp_api/client/routes/electrodes.py
@@ -127,13 +127,17 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
+            query_params.update(
+                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
+            )
 
         if exclude_elements:
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
         for param, value in locals().items():
             if (
@@ -148,10 +152,16 @@ class ElectrodeRester(BaseRester[InsertionElectrodeDoc]):
                 and value
             ):
                 if isinstance(value, tuple):
-                    query_params.update({f"{param}_min": value[0], f"{param}_max": value[1]})
+                    query_params.update(
+                        {f"{param}_min": value[0], f"{param}_max": value[1]}
+                    )
                 else:
                     query_params.update({param: value})
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(**query_params)

--- a/mp_api/client/routes/electronic_structure.py
+++ b/mp_api/client/routes/electronic_structure.py
@@ -109,7 +109,9 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if band_gap:
-            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
+            query_params.update(
+                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
+            )
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -120,7 +122,9 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
+            query_params.update(
+                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
+            )
 
         if is_gap_direct is not None:
             query_params.update({"is_gap_direct": is_gap_direct})
@@ -129,9 +133,15 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"is_metal": is_metal})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,
@@ -195,7 +205,9 @@ class BandStructureRester(BaseRester):
         query_params["path_type"] = path_type.value
 
         if band_gap:
-            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
+            query_params.update(
+                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
+            )
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -210,9 +222,15 @@ class BandStructureRester(BaseRester):
             query_params.update({"is_metal": is_metal})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,
@@ -260,32 +278,46 @@ class BandStructureRester(BaseRester):
         Returns:
             bandstructure (Union[BandStructure, BandStructureSymmLine]): BandStructure or BandStructureSymmLine object
         """
-        es_rester = ElectronicStructureRester(endpoint=self.base_endpoint, api_key=self.api_key)
+        es_rester = ElectronicStructureRester(
+            endpoint=self.base_endpoint, api_key=self.api_key
+        )
 
         if line_mode:
-            bs_data = es_rester.get_data_by_id(document_id=material_id, fields=["bandstructure"]).bandstructure
+            bs_data = es_rester.get_data_by_id(
+                document_id=material_id, fields=["bandstructure"]
+            ).bandstructure
 
             if bs_data is None:
-                raise MPRestError(f"No {path_type.value} band structure data found for {material_id}")
+                raise MPRestError(
+                    f"No {path_type.value} band structure data found for {material_id}"
+                )
             else:
                 bs_data = bs_data.dict()
 
             if bs_data.get(path_type.value, None):
                 bs_task_id = bs_data[path_type.value]["task_id"]
             else:
-                raise MPRestError(f"No {path_type.value} band structure data found for {material_id}")
+                raise MPRestError(
+                    f"No {path_type.value} band structure data found for {material_id}"
+                )
         else:
-            bs_data = es_rester.get_data_by_id(document_id=material_id, fields=["dos"]).dos
+            bs_data = es_rester.get_data_by_id(
+                document_id=material_id, fields=["dos"]
+            ).dos
 
             if bs_data is None:
-                raise MPRestError(f"No uniform band structure data found for {material_id}")
+                raise MPRestError(
+                    f"No uniform band structure data found for {material_id}"
+                )
             else:
                 bs_data = bs_data.dict()
 
             if bs_data.get("total", None):
                 bs_task_id = bs_data["total"]["1"]["task_id"]
             else:
-                raise MPRestError(f"No uniform band structure data found for {material_id}")
+                raise MPRestError(
+                    f"No uniform band structure data found for {material_id}"
+                )
 
         bs_obj = self.get_bandstructure_from_task_id(bs_task_id)
 
@@ -362,7 +394,9 @@ class DosRester(BaseRester):
             query_params["orbital"] = orbital.value
 
         if band_gap:
-            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
+            query_params.update(
+                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
+            )
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -371,9 +405,15 @@ class DosRester(BaseRester):
             query_params.update({"magnetic_ordering": magnetic_ordering.value})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,
@@ -414,9 +454,13 @@ class DosRester(BaseRester):
         Returns:
             dos (CompleteDos): CompleteDos object
         """
-        es_rester = ElectronicStructureRester(endpoint=self.base_endpoint, api_key=self.api_key)
+        es_rester = ElectronicStructureRester(
+            endpoint=self.base_endpoint, api_key=self.api_key
+        )
 
-        dos_data = es_rester.get_data_by_id(document_id=material_id, fields=["dos"]).dict()
+        dos_data = es_rester.get_data_by_id(
+            document_id=material_id, fields=["dos"]
+        ).dict()
 
         if dos_data["dos"]:
             dos_task_id = dos_data["dos"]["total"]["1"]["task_id"]

--- a/mp_api/client/routes/electronic_structure.py
+++ b/mp_api/client/routes/electronic_structure.py
@@ -20,7 +20,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
-    suffix = "electronic_structure"
+    suffix = "materials/electronic_structure"
     document_model = ElectronicStructureDoc  # type: ignore
     primary_key = "material_id"
 
@@ -109,9 +109,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"exclude_elements": ",".join(exclude_elements)})
 
         if band_gap:
-            query_params.update(
-                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
-            )
+            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -122,9 +120,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if is_gap_direct is not None:
             query_params.update({"is_gap_direct": is_gap_direct})
@@ -133,15 +129,9 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
             query_params.update({"is_metal": is_metal})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -153,7 +143,7 @@ class ElectronicStructureRester(BaseRester[ElectronicStructureDoc]):
 
 
 class BandStructureRester(BaseRester):
-    suffix = "electronic_structure/bandstructure"
+    suffix = "materials/electronic_structure/bandstructure"
     document_model = ElectronicStructureDoc  # type: ignore
 
     def search_bandstructure_summary(self, *args, **kwargs):  # pragma: no cover
@@ -205,9 +195,7 @@ class BandStructureRester(BaseRester):
         query_params["path_type"] = path_type.value
 
         if band_gap:
-            query_params.update(
-                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
-            )
+            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -222,15 +210,9 @@ class BandStructureRester(BaseRester):
             query_params.update({"is_metal": is_metal})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -278,46 +260,32 @@ class BandStructureRester(BaseRester):
         Returns:
             bandstructure (Union[BandStructure, BandStructureSymmLine]): BandStructure or BandStructureSymmLine object
         """
-        es_rester = ElectronicStructureRester(
-            endpoint=self.base_endpoint, api_key=self.api_key
-        )
+        es_rester = ElectronicStructureRester(endpoint=self.base_endpoint, api_key=self.api_key)
 
         if line_mode:
-            bs_data = es_rester.get_data_by_id(
-                document_id=material_id, fields=["bandstructure"]
-            ).bandstructure
+            bs_data = es_rester.get_data_by_id(document_id=material_id, fields=["bandstructure"]).bandstructure
 
             if bs_data is None:
-                raise MPRestError(
-                    f"No {path_type.value} band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No {path_type.value} band structure data found for {material_id}")
             else:
                 bs_data = bs_data.dict()
 
             if bs_data.get(path_type.value, None):
                 bs_task_id = bs_data[path_type.value]["task_id"]
             else:
-                raise MPRestError(
-                    f"No {path_type.value} band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No {path_type.value} band structure data found for {material_id}")
         else:
-            bs_data = es_rester.get_data_by_id(
-                document_id=material_id, fields=["dos"]
-            ).dos
+            bs_data = es_rester.get_data_by_id(document_id=material_id, fields=["dos"]).dos
 
             if bs_data is None:
-                raise MPRestError(
-                    f"No uniform band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No uniform band structure data found for {material_id}")
             else:
                 bs_data = bs_data.dict()
 
             if bs_data.get("total", None):
                 bs_task_id = bs_data["total"]["1"]["task_id"]
             else:
-                raise MPRestError(
-                    f"No uniform band structure data found for {material_id}"
-                )
+                raise MPRestError(f"No uniform band structure data found for {material_id}")
 
         bs_obj = self.get_bandstructure_from_task_id(bs_task_id)
 
@@ -333,7 +301,7 @@ class BandStructureRester(BaseRester):
 
 
 class DosRester(BaseRester):
-    suffix = "electronic_structure/dos"
+    suffix = "materials/electronic_structure/dos"
     document_model = ElectronicStructureDoc  # type: ignore
 
     def search_dos_summary(self, *args, **kwargs):  # pragma: no cover
@@ -394,9 +362,7 @@ class DosRester(BaseRester):
             query_params["orbital"] = orbital.value
 
         if band_gap:
-            query_params.update(
-                {"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]}
-            )
+            query_params.update({"band_gap_min": band_gap[0], "band_gap_max": band_gap[1]})
 
         if efermi:
             query_params.update({"efermi_min": efermi[0], "efermi_max": efermi[1]})
@@ -405,15 +371,9 @@ class DosRester(BaseRester):
             query_params.update({"magnetic_ordering": magnetic_ordering.value})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -454,13 +414,9 @@ class DosRester(BaseRester):
         Returns:
             dos (CompleteDos): CompleteDos object
         """
-        es_rester = ElectronicStructureRester(
-            endpoint=self.base_endpoint, api_key=self.api_key
-        )
+        es_rester = ElectronicStructureRester(endpoint=self.base_endpoint, api_key=self.api_key)
 
-        dos_data = es_rester.get_data_by_id(
-            document_id=material_id, fields=["dos"]
-        ).dict()
+        dos_data = es_rester.get_data_by_id(document_id=material_id, fields=["dos"]).dict()
 
         if dos_data["dos"]:
             dos_task_id = dos_data["dos"]["total"]["1"]["task_id"]

--- a/mp_api/client/routes/eos.py
+++ b/mp_api/client/routes/eos.py
@@ -15,7 +15,8 @@ class EOSRester(BaseRester[EOSDoc]):
     def search_eos_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.eos.search_eos_docs is deprecated. " "Please use MPRester.eos.search instead.",
+            "MPRester.eos.search_eos_docs is deprecated. "
+            "Please use MPRester.eos.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -53,13 +54,25 @@ class EOSRester(BaseRester[EOSDoc]):
             query_params.update({"volumes_min": volumes[0], "volumes_max": volumes[1]})
 
         if energies:
-            query_params.update({"energies_min": energies[0], "energies_max": energies[1]})
+            query_params.update(
+                {"energies_min": energies[0], "energies_max": energies[1]}
+            )
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/eos.py
+++ b/mp_api/client/routes/eos.py
@@ -8,15 +8,14 @@ from mp_api.client.core import BaseRester
 
 
 class EOSRester(BaseRester[EOSDoc]):
-    suffix = "eos"
+    suffix = "materials/eos"
     document_model = EOSDoc  # type: ignore
     primary_key = "task_id"
 
     def search_eos_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.eos.search_eos_docs is deprecated. "
-            "Please use MPRester.eos.search instead.",
+            "MPRester.eos.search_eos_docs is deprecated. " "Please use MPRester.eos.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -54,25 +53,13 @@ class EOSRester(BaseRester[EOSDoc]):
             query_params.update({"volumes_min": volumes[0], "volumes_max": volumes[1]})
 
         if energies:
-            query_params.update(
-                {"energies_min": energies[0], "energies_max": energies[1]}
-            )
+            query_params.update({"energies_min": energies[0], "energies_max": energies[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/fermi.py
+++ b/mp_api/client/routes/fermi.py
@@ -6,7 +6,7 @@ from mp_api.client.core import BaseRester
 
 
 class FermiRester(BaseRester[FermiDoc]):
-    suffix = "fermi"
+    suffix = "materials/fermi"
     document_model = FermiDoc  # type: ignore
     primary_key = "task_id"
 

--- a/mp_api/client/routes/grain_boundary.py
+++ b/mp_api/client/routes/grain_boundary.py
@@ -9,7 +9,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
-    suffix = "grain_boundary"
+    suffix = "materials/grain_boundary"
     document_model = GrainBoundaryDoc  # type: ignore
     primary_key = "task_id"
 
@@ -75,14 +75,10 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             query_params.update({"gb_plane": ",".join([str(n) for n in gb_plane])})
 
         if gb_energy:
-            query_params.update(
-                {"gb_energy_min": gb_energy[0], "gb_energy_max": gb_energy[1]}
-            )
+            query_params.update({"gb_energy_min": gb_energy[0], "gb_energy_max": gb_energy[1]})
 
         if separation_energy:
-            query_params.update(
-                {"w_sep_min": separation_energy[0], "w_sep_max": separation_energy[1]}
-            )
+            query_params.update({"w_sep_min": separation_energy[0], "w_sep_max": separation_energy[1]})
 
         if rotation_angle:
             query_params.update(
@@ -93,9 +89,7 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             )
 
         if rotation_axis:
-            query_params.update(
-                {"rotation_axis": ",".join([str(n) for n in rotation_axis])}
-            )
+            query_params.update({"rotation_axis": ",".join([str(n) for n in rotation_axis])})
 
         if sigma:
             query_params.update({"sigma": sigma})
@@ -110,20 +104,10 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             query_params.update({"pretty_formula": pretty_formula})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/grain_boundary.py
+++ b/mp_api/client/routes/grain_boundary.py
@@ -75,10 +75,14 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             query_params.update({"gb_plane": ",".join([str(n) for n in gb_plane])})
 
         if gb_energy:
-            query_params.update({"gb_energy_min": gb_energy[0], "gb_energy_max": gb_energy[1]})
+            query_params.update(
+                {"gb_energy_min": gb_energy[0], "gb_energy_max": gb_energy[1]}
+            )
 
         if separation_energy:
-            query_params.update({"w_sep_min": separation_energy[0], "w_sep_max": separation_energy[1]})
+            query_params.update(
+                {"w_sep_min": separation_energy[0], "w_sep_max": separation_energy[1]}
+            )
 
         if rotation_angle:
             query_params.update(
@@ -89,7 +93,9 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             )
 
         if rotation_axis:
-            query_params.update({"rotation_axis": ",".join([str(n) for n in rotation_axis])})
+            query_params.update(
+                {"rotation_axis": ",".join([str(n) for n in rotation_axis])}
+            )
 
         if sigma:
             query_params.update({"sigma": sigma})
@@ -104,10 +110,20 @@ class GrainBoundaryRester(BaseRester[GrainBoundaryDoc]):
             query_params.update({"pretty_formula": pretty_formula})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/magnetism.py
+++ b/mp_api/client/routes/magnetism.py
@@ -10,15 +10,14 @@ from mp_api.client.core.utils import validate_ids
 
 
 class MagnetismRester(BaseRester[MagnetismDoc]):
-    suffix = "magnetism"
+    suffix = "materials/magnetism"
     document_model = MagnetismDoc  # type: ignore
     primary_key = "material_id"
 
     def search_magnetism_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.magnetism.search_magnetism_docs is deprecated. "
-            "Please use MPRester.magnetism.search instead.",
+            "MPRester.magnetism.search_magnetism_docs is deprecated. " "Please use MPRester.magnetism.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -33,9 +32,7 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         ordering: Optional[Ordering] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[
-            Tuple[float, float]
-        ] = None,
+        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
         sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
         chunk_size: int = 1000,
@@ -85,24 +82,16 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         if total_magnetization_normalized_vol:
             query_params.update(
                 {
-                    "total_magnetization_normalized_vol_min": total_magnetization_normalized_vol[
-                        0
-                    ],
-                    "total_magnetization_normalized_vol_max": total_magnetization_normalized_vol[
-                        1
-                    ],
+                    "total_magnetization_normalized_vol_min": total_magnetization_normalized_vol[0],
+                    "total_magnetization_normalized_vol_max": total_magnetization_normalized_vol[1],
                 }
             )
 
         if total_magnetization_normalized_formula_units:
             query_params.update(
                 {
-                    "total_magnetization_normalized_formula_units_min": total_magnetization_normalized_formula_units[
-                        0
-                    ],
-                    "total_magnetization_normalized_formula_units_max": total_magnetization_normalized_formula_units[
-                        1
-                    ],
+                    "total_magnetization_normalized_formula_units_min": total_magnetization_normalized_formula_units[0],
+                    "total_magnetization_normalized_formula_units_max": total_magnetization_normalized_formula_units[1],
                 }
             )
 
@@ -126,20 +115,10 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
             query_params.update({"ordering": ordering.value})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/magnetism.py
+++ b/mp_api/client/routes/magnetism.py
@@ -17,7 +17,8 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
     def search_magnetism_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.magnetism.search_magnetism_docs is deprecated. " "Please use MPRester.magnetism.search instead.",
+            "MPRester.magnetism.search_magnetism_docs is deprecated. "
+            "Please use MPRester.magnetism.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -32,7 +33,9 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         ordering: Optional[Ordering] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
+        total_magnetization_normalized_formula_units: Optional[
+            Tuple[float, float]
+        ] = None,
         sort_fields: Optional[List[str]] = None,
         num_chunks: Optional[int] = None,
         chunk_size: int = 1000,
@@ -82,16 +85,24 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
         if total_magnetization_normalized_vol:
             query_params.update(
                 {
-                    "total_magnetization_normalized_vol_min": total_magnetization_normalized_vol[0],
-                    "total_magnetization_normalized_vol_max": total_magnetization_normalized_vol[1],
+                    "total_magnetization_normalized_vol_min": total_magnetization_normalized_vol[
+                        0
+                    ],
+                    "total_magnetization_normalized_vol_max": total_magnetization_normalized_vol[
+                        1
+                    ],
                 }
             )
 
         if total_magnetization_normalized_formula_units:
             query_params.update(
                 {
-                    "total_magnetization_normalized_formula_units_min": total_magnetization_normalized_formula_units[0],
-                    "total_magnetization_normalized_formula_units_max": total_magnetization_normalized_formula_units[1],
+                    "total_magnetization_normalized_formula_units_min": total_magnetization_normalized_formula_units[
+                        0
+                    ],
+                    "total_magnetization_normalized_formula_units_max": total_magnetization_normalized_formula_units[
+                        1
+                    ],
                 }
             )
 
@@ -115,10 +126,20 @@ class MagnetismRester(BaseRester[MagnetismDoc]):
             query_params.update({"ordering": ordering.value})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/materials.py
+++ b/mp_api/client/routes/materials.py
@@ -13,14 +13,12 @@ _EMMET_SETTINGS = EmmetSettings()
 
 
 class MaterialsRester(BaseRester[MaterialsDoc]):
-    suffix = "materials"
+    suffix = "materials/core"
     document_model = MaterialsDoc  # type: ignore
     supports_versions = True
     primary_key = "material_id"
 
-    def get_structure_by_material_id(
-        self, material_id: str, final: bool = True
-    ) -> Union[Structure, List[Structure]]:
+    def get_structure_by_material_id(self, material_id: str, final: bool = True) -> Union[Structure, List[Structure]]:
         """Get a structure for a given Materials Project ID.
 
         Arguments:
@@ -42,8 +40,7 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
     def search_material_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.materials.search_material_docs is deprecated. "
-            "Please use MPRester.materials.search instead.",
+            "MPRester.materials.search_material_docs is deprecated. " "Please use MPRester.materials.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -141,16 +138,12 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
         )
 
         if num_sites:
-            query_params.update(
-                {"nsites_min": num_sites[0], "nsites_max": num_sites[1]}
-            )
+            query_params.update({"nsites_min": num_sites[0], "nsites_max": num_sites[1]})
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if volume:
             query_params.update({"volume_min": volume[0], "volume_max": volume[1]})
@@ -159,15 +152,9 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
             query_params.update({"density_min": density[0], "density_max": density[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/materials.py
+++ b/mp_api/client/routes/materials.py
@@ -18,7 +18,9 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
     supports_versions = True
     primary_key = "material_id"
 
-    def get_structure_by_material_id(self, material_id: str, final: bool = True) -> Union[Structure, List[Structure]]:
+    def get_structure_by_material_id(
+        self, material_id: str, final: bool = True
+    ) -> Union[Structure, List[Structure]]:
         """Get a structure for a given Materials Project ID.
 
         Arguments:
@@ -40,7 +42,8 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
     def search_material_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.materials.search_material_docs is deprecated. " "Please use MPRester.materials.search instead.",
+            "MPRester.materials.search_material_docs is deprecated. "
+            "Please use MPRester.materials.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -138,12 +141,16 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
         )
 
         if num_sites:
-            query_params.update({"nsites_min": num_sites[0], "nsites_max": num_sites[1]})
+            query_params.update(
+                {"nsites_min": num_sites[0], "nsites_max": num_sites[1]}
+            )
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
+            query_params.update(
+                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
+            )
 
         if volume:
             query_params.update({"volume_min": volume[0], "volume_max": volume[1]})
@@ -152,9 +159,15 @@ class MaterialsRester(BaseRester[MaterialsDoc]):
             query_params.update({"density_min": density[0], "density_max": density[1]})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/molecules.py
+++ b/mp_api/client/routes/molecules.py
@@ -9,15 +9,14 @@ from mp_api.client.core import BaseRester
 
 
 class MoleculesRester(BaseRester[MoleculesDoc]):
-    suffix = "molecules"
+    suffix = "legacy/jcesr"
     document_model = MoleculesDoc  # type: ignore
     primary_key = "task_id"
 
     def search_molecules_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.molecules.search_molecules_docs is deprecated. "
-            "Please use MPRester.molecules.search instead.",
+            "MPRester.molecules.search_molecules_docs is deprecated. " "Please use MPRester.molecules.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -72,9 +71,7 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
             query_params.update({"smiles": smiles})
 
         if nelements:
-            query_params.update(
-                {"nelements_min": nelements[0], "nelements_max": nelements[1]}
-            )
+            query_params.update({"nelements_min": nelements[0], "nelements_max": nelements[1]})
 
         if EA:
             query_params.update({"EA_min": EA[0], "EA_max": EA[1]})
@@ -86,20 +83,10 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
             query_params.update({"charge_min": charge[0], "charge_max": charge[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/molecules.py
+++ b/mp_api/client/routes/molecules.py
@@ -16,7 +16,8 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
     def search_molecules_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.molecules.search_molecules_docs is deprecated. " "Please use MPRester.molecules.search instead.",
+            "MPRester.molecules.search_molecules_docs is deprecated. "
+            "Please use MPRester.molecules.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -71,7 +72,9 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
             query_params.update({"smiles": smiles})
 
         if nelements:
-            query_params.update({"nelements_min": nelements[0], "nelements_max": nelements[1]})
+            query_params.update(
+                {"nelements_min": nelements[0], "nelements_max": nelements[1]}
+            )
 
         if EA:
             query_params.update({"EA_min": EA[0], "EA_max": EA[1]})
@@ -83,10 +86,20 @@ class MoleculesRester(BaseRester[MoleculesDoc]):
             query_params.update({"charge_min": charge[0], "charge_max": charge[1]})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/oxidation_states.py
+++ b/mp_api/client/routes/oxidation_states.py
@@ -8,7 +8,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class OxidationStatesRester(BaseRester[OxidationStateDoc]):
-    suffix = "oxidation_states"
+    suffix = "materials/oxidation_states"
     document_model = OxidationStateDoc  # type: ignore
     primary_key = "material_id"
 
@@ -69,20 +69,10 @@ class OxidationStatesRester(BaseRester[OxidationStateDoc]):
             query_params.update({"possible_species": ",".join(possible_species)})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/oxidation_states.py
+++ b/mp_api/client/routes/oxidation_states.py
@@ -69,10 +69,20 @@ class OxidationStatesRester(BaseRester[OxidationStateDoc]):
             query_params.update({"possible_species": ",".join(possible_species)})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/phonon.py
+++ b/mp_api/client/routes/phonon.py
@@ -4,7 +4,7 @@ from mp_api.client.core import BaseRester
 
 
 class PhononRester(BaseRester[PhononBSDOSDoc]):
-    suffix = "phonon"
+    suffix = "materials/phonon"
     document_model = PhononBSDOSDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/piezo.py
+++ b/mp_api/client/routes/piezo.py
@@ -68,10 +68,20 @@ class PiezoRester(BaseRester[PiezoelectricDoc]):
             )
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/piezo.py
+++ b/mp_api/client/routes/piezo.py
@@ -9,7 +9,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class PiezoRester(BaseRester[PiezoelectricDoc]):
-    suffix = "piezoelectric"
+    suffix = "materials/piezoelectric"
     document_model = PiezoelectricDoc  # type: ignore
     primary_key = "material_id"
 
@@ -68,20 +68,10 @@ class PiezoRester(BaseRester[PiezoelectricDoc]):
             )
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/provenance.py
+++ b/mp_api/client/routes/provenance.py
@@ -7,7 +7,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ProvenanceRester(BaseRester[ProvenanceDoc]):
-    suffix = "provenance"
+    suffix = "materials/provenance"
     document_model = ProvenanceDoc  # type: ignore
     primary_key = "material_id"
 
@@ -44,9 +44,5 @@ class ProvenanceRester(BaseRester[ProvenanceDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/provenance.py
+++ b/mp_api/client/routes/provenance.py
@@ -44,5 +44,9 @@ class ProvenanceRester(BaseRester[ProvenanceDoc]):
             query_params.update({"material_ids": ",".join(validate_ids(material_ids))})
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/robocrys.py
+++ b/mp_api/client/routes/robocrys.py
@@ -7,7 +7,7 @@ from mp_api.client.core import BaseRester, MPRestError
 
 
 class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
-    suffix = "robocrys"
+    suffix = "materials/robocrys"
     document_model = RobocrystallogapherDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/similarity.py
+++ b/mp_api/client/routes/similarity.py
@@ -4,7 +4,7 @@ from mp_api.client.core import BaseRester
 
 
 class SimilarityRester(BaseRester[SimilarityDoc]):
-    suffix = "similarity"
+    suffix = "materials/similarity"
     document_model = SimilarityDoc  # type: ignore
     primary_key = "material_id"
 

--- a/mp_api/client/routes/substrates.py
+++ b/mp_api/client/routes/substrates.py
@@ -71,10 +71,18 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
             query_params.update({"sub_form": substrate_formula})
 
         if film_orientation:
-            query_params.update({"film_orientation": ",".join([str(i) for i in film_orientation])})
+            query_params.update(
+                {"film_orientation": ",".join([str(i) for i in film_orientation])}
+            )
 
         if substrate_orientation:
-            query_params.update({"substrate_orientation": ",".join([str(i) for i in substrate_orientation])})
+            query_params.update(
+                {
+                    "substrate_orientation": ",".join(
+                        [str(i) for i in substrate_orientation]
+                    )
+                }
+            )
 
         if area:
             query_params.update({"area_min": area[0], "area_max": area[1]})
@@ -83,9 +91,15 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
             query_params.update({"energy_min": energy[0], "energy_max": energy[1]})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             **query_params,

--- a/mp_api/client/routes/substrates.py
+++ b/mp_api/client/routes/substrates.py
@@ -8,7 +8,7 @@ from mp_api.client.core import BaseRester
 
 
 class SubstratesRester(BaseRester[SubstratesDoc]):
-    suffix = "substrates"
+    suffix = "materials/substrates"
     document_model = SubstratesDoc  # type: ignore
     primary_key = "film_id"
 
@@ -71,18 +71,10 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
             query_params.update({"sub_form": substrate_formula})
 
         if film_orientation:
-            query_params.update(
-                {"film_orientation": ",".join([str(i) for i in film_orientation])}
-            )
+            query_params.update({"film_orientation": ",".join([str(i) for i in film_orientation])})
 
         if substrate_orientation:
-            query_params.update(
-                {
-                    "substrate_orientation": ",".join(
-                        [str(i) for i in substrate_orientation]
-                    )
-                }
-            )
+            query_params.update({"substrate_orientation": ",".join([str(i) for i in substrate_orientation])})
 
         if area:
             query_params.update({"area_min": area[0], "area_max": area[1]})
@@ -91,15 +83,9 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
             query_params.update({"energy_min": energy[0], "energy_max": energy[1]})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             **query_params,

--- a/mp_api/client/routes/summary.py
+++ b/mp_api/client/routes/summary.py
@@ -19,7 +19,8 @@ class SummaryRester(BaseRester[SummaryDoc]):
     def search_summary_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.summary.search_summary_docs is deprecated. " "Please use MPRester.summary.search instead.",
+            "MPRester.summary.search_summary_docs is deprecated. "
+            "Please use MPRester.summary.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -72,7 +73,9 @@ class SummaryRester(BaseRester[SummaryDoc]):
         theoretical: Optional[bool] = None,
         total_energy: Optional[Tuple[float, float]] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
+        total_magnetization_normalized_formula_units: Optional[
+            Tuple[float, float]
+        ] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
         uncorrected_energy: Optional[Tuple[float, float]] = None,
         volume: Optional[Tuple[float, float]] = None,
@@ -267,9 +270,15 @@ class SummaryRester(BaseRester[SummaryDoc]):
             query_params.update({"theoretical": theoretical})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/summary.py
+++ b/mp_api/client/routes/summary.py
@@ -12,15 +12,14 @@ from mp_api.client.core.utils import validate_ids
 
 
 class SummaryRester(BaseRester[SummaryDoc]):
-    suffix = "summary"
+    suffix = "materials/summary"
     document_model = SummaryDoc  # type: ignore
     primary_key = "material_id"
 
     def search_summary_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.summary.search_summary_docs is deprecated. "
-            "Please use MPRester.summary.search instead.",
+            "MPRester.summary.search_summary_docs is deprecated. " "Please use MPRester.summary.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -73,9 +72,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
         theoretical: Optional[bool] = None,
         total_energy: Optional[Tuple[float, float]] = None,
         total_magnetization: Optional[Tuple[float, float]] = None,
-        total_magnetization_normalized_formula_units: Optional[
-            Tuple[float, float]
-        ] = None,
+        total_magnetization_normalized_formula_units: Optional[Tuple[float, float]] = None,
         total_magnetization_normalized_vol: Optional[Tuple[float, float]] = None,
         uncorrected_energy: Optional[Tuple[float, float]] = None,
         volume: Optional[Tuple[float, float]] = None,
@@ -270,15 +267,9 @@ class SummaryRester(BaseRester[SummaryDoc]):
             query_params.update({"theoretical": theoretical})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/surface_properties.py
+++ b/mp_api/client/routes/surface_properties.py
@@ -94,10 +94,20 @@ class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
             query_params.update({"has_reconstructed": has_reconstructed})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
-            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
+            num_chunks=num_chunks,
+            chunk_size=chunk_size,
+            all_fields=all_fields,
+            fields=fields,
+            **query_params
         )

--- a/mp_api/client/routes/surface_properties.py
+++ b/mp_api/client/routes/surface_properties.py
@@ -8,7 +8,7 @@ from mp_api.client.core import BaseRester
 
 
 class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
-    suffix = "surface_properties"
+    suffix = "materials/surface_properties"
     document_model = SurfacePropDoc  # type: ignore
     primary_key = "task_id"
 
@@ -94,20 +94,10 @@ class SurfacePropertiesRester(BaseRester[SurfacePropDoc]):
             query_params.update({"has_reconstructed": has_reconstructed})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
-            num_chunks=num_chunks,
-            chunk_size=chunk_size,
-            all_fields=all_fields,
-            fields=fields,
-            **query_params
+            num_chunks=num_chunks, chunk_size=chunk_size, all_fields=all_fields, fields=fields, **query_params
         )

--- a/mp_api/client/routes/synthesis.py
+++ b/mp_api/client/routes/synthesis.py
@@ -11,7 +11,7 @@ from mp_api.client.core import BaseRester, MPRestError
 
 
 class SynthesisRester(BaseRester[SynthesisSearchResultModel]):
-    suffix = "synthesis"
+    suffix = "materials/synthesis"
     document_model = SynthesisSearchResultModel  # type: ignore
 
     def search_synthesis_text(self, *args, **kwargs):  # pragma: no cover

--- a/mp_api/client/routes/tasks.py
+++ b/mp_api/client/routes/tasks.py
@@ -8,7 +8,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class TaskRester(BaseRester[TaskDoc]):
-    suffix = "tasks"
+    suffix = "materials/tasks"
     document_model = TaskDoc  # type: ignore
     primary_key = "task_id"
 
@@ -20,9 +20,9 @@ class TaskRester(BaseRester[TaskDoc]):
         :param task_id: A specified task_id
         :return: List of trajectory objects
         """
-        traj_data = self._query_resource_data(
-            suburl=f"trajectory/{task_id}/", use_document_model=False
-        )[0].get("trajectories", None)
+        traj_data = self._query_resource_data(suburl=f"trajectory/{task_id}/", use_document_model=False)[0].get(
+            "trajectories", None
+        )
 
         if traj_data is None:
             raise MPRestError(f"No trajectory data for {task_id} found")
@@ -32,8 +32,7 @@ class TaskRester(BaseRester[TaskDoc]):
     def search_task_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.tasks.search_task_docs is deprecated. "
-            "Please use MPRester.tasks.search instead.",
+            "MPRester.tasks.search_task_docs is deprecated. " "Please use MPRester.tasks.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/mp_api/client/routes/tasks.py
+++ b/mp_api/client/routes/tasks.py
@@ -20,9 +20,9 @@ class TaskRester(BaseRester[TaskDoc]):
         :param task_id: A specified task_id
         :return: List of trajectory objects
         """
-        traj_data = self._query_resource_data(suburl=f"trajectory/{task_id}/", use_document_model=False)[0].get(
-            "trajectories", None
-        )
+        traj_data = self._query_resource_data(
+            suburl=f"trajectory/{task_id}/", use_document_model=False
+        )[0].get("trajectories", None)
 
         if traj_data is None:
             raise MPRestError(f"No trajectory data for {task_id} found")
@@ -32,7 +32,8 @@ class TaskRester(BaseRester[TaskDoc]):
     def search_task_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.tasks.search_task_docs is deprecated. " "Please use MPRester.tasks.search instead.",
+            "MPRester.tasks.search_task_docs is deprecated. "
+            "Please use MPRester.tasks.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -20,7 +20,8 @@ class ThermoRester(BaseRester[ThermoDoc]):
     def search_thermo_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.thermo.search_thermo_docs is deprecated. " "Please use MPRester.thermo.search instead.",
+            "MPRester.thermo.search_thermo_docs is deprecated. "
+            "Please use MPRester.thermo.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -102,19 +103,25 @@ class ThermoRester(BaseRester[ThermoDoc]):
             t_types = {t if isinstance(t, str) else t.value for t in thermo_types}
             valid_types = {*map(str, ThermoType.__members__.values())}
             if invalid_types := t_types - valid_types:
-                raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
+                raise ValueError(
+                    f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
+                )
             query_params.update({"thermo_types": ",".join(t_types)})
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
+            query_params.update(
+                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
+            )
 
         if is_stable is not None:
             query_params.update({"is_stable": is_stable})
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
         name_dict = {
             "total_energy": "energy_per_atom",
@@ -133,7 +140,11 @@ class ThermoRester(BaseRester[ThermoDoc]):
                     }
                 )
 
-        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
+        query_params = {
+            entry: query_params[entry]
+            for entry in query_params
+            if query_params[entry] is not None
+        }
 
         return super()._search(
             num_chunks=num_chunks,
@@ -143,7 +154,9 @@ class ThermoRester(BaseRester[ThermoDoc]):
             **query_params,
         )
 
-    def get_phase_diagram_from_chemsys(self, chemsys: str, thermo_type: Union[ThermoType, str]) -> PhaseDiagram:
+    def get_phase_diagram_from_chemsys(
+        self, chemsys: str, thermo_type: Union[ThermoType, str]
+    ) -> PhaseDiagram:
         """Get a pre-computed phase diagram for a given chemsys.
 
         Arguments:
@@ -158,7 +171,9 @@ class ThermoRester(BaseRester[ThermoDoc]):
         t_type = thermo_type if isinstance(thermo_type, str) else thermo_type.value
         valid_types = {*map(str, ThermoType.__members__.values())}
         if invalid_types := {t_type} - valid_types:
-            raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
+            raise ValueError(
+                f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
+            )
 
         sorted_chemsys = "-".join(sorted(chemsys.split("-")))
         phase_diagram_id = f"{sorted_chemsys}_{t_type}"

--- a/mp_api/client/routes/thermo.py
+++ b/mp_api/client/routes/thermo.py
@@ -12,7 +12,7 @@ from mp_api.client.core.utils import validate_ids
 
 
 class ThermoRester(BaseRester[ThermoDoc]):
-    suffix = "thermo"
+    suffix = "materials/thermo"
     document_model = ThermoDoc  # type: ignore
     supports_versions = True
     primary_key = "thermo_id"
@@ -20,8 +20,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
     def search_thermo_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.thermo.search_thermo_docs is deprecated. "
-            "Please use MPRester.thermo.search instead.",
+            "MPRester.thermo.search_thermo_docs is deprecated. " "Please use MPRester.thermo.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -103,25 +102,19 @@ class ThermoRester(BaseRester[ThermoDoc]):
             t_types = {t if isinstance(t, str) else t.value for t in thermo_types}
             valid_types = {*map(str, ThermoType.__members__.values())}
             if invalid_types := t_types - valid_types:
-                raise ValueError(
-                    f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
-                )
+                raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
             query_params.update({"thermo_types": ",".join(t_types)})
 
         if num_elements:
             if isinstance(num_elements, int):
                 num_elements = (num_elements, num_elements)
-            query_params.update(
-                {"nelements_min": num_elements[0], "nelements_max": num_elements[1]}
-            )
+            query_params.update({"nelements_min": num_elements[0], "nelements_max": num_elements[1]})
 
         if is_stable is not None:
             query_params.update({"is_stable": is_stable})
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
         name_dict = {
             "total_energy": "energy_per_atom",
@@ -140,11 +133,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
                     }
                 )
 
-        query_params = {
-            entry: query_params[entry]
-            for entry in query_params
-            if query_params[entry] is not None
-        }
+        query_params = {entry: query_params[entry] for entry in query_params if query_params[entry] is not None}
 
         return super()._search(
             num_chunks=num_chunks,
@@ -154,9 +143,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
             **query_params,
         )
 
-    def get_phase_diagram_from_chemsys(
-        self, chemsys: str, thermo_type: Union[ThermoType, str]
-    ) -> PhaseDiagram:
+    def get_phase_diagram_from_chemsys(self, chemsys: str, thermo_type: Union[ThermoType, str]) -> PhaseDiagram:
         """Get a pre-computed phase diagram for a given chemsys.
 
         Arguments:
@@ -171,9 +158,7 @@ class ThermoRester(BaseRester[ThermoDoc]):
         t_type = thermo_type if isinstance(thermo_type, str) else thermo_type.value
         valid_types = {*map(str, ThermoType.__members__.values())}
         if invalid_types := {t_type} - valid_types:
-            raise ValueError(
-                f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}"
-            )
+            raise ValueError(f"Invalid thermo type(s) passed: {invalid_types}, valid types are: {valid_types}")
 
         sorted_chemsys = "-".join(sorted(chemsys.split("-")))
         phase_diagram_id = f"{sorted_chemsys}_{t_type}"

--- a/mp_api/client/routes/xas.py
+++ b/mp_api/client/routes/xas.py
@@ -9,15 +9,14 @@ from mp_api.client.core.utils import validate_ids
 
 
 class XASRester(BaseRester[XASDoc]):
-    suffix = "xas"
+    suffix = "materials/xas"
     document_model = XASDoc  # type: ignore
     primary_key = "spectrum_id"
 
     def search_xas_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.xas.search_xas_docs is deprecated. "
-            "Please use MPRester.xas.search instead.",
+            "MPRester.xas.search_xas_docs is deprecated. " "Please use MPRester.xas.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -94,9 +93,7 @@ class XASRester(BaseRester[XASDoc]):
             query_params["material_ids"] = ",".join(validate_ids(material_ids))
 
         if sort_fields:
-            query_params.update(
-                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
-            )
+            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
 
         return super()._search(
             num_chunks=num_chunks,

--- a/mp_api/client/routes/xas.py
+++ b/mp_api/client/routes/xas.py
@@ -16,7 +16,8 @@ class XASRester(BaseRester[XASDoc]):
     def search_xas_docs(self, *args, **kwargs):  # pragma: no cover
         """Deprecated."""
         warnings.warn(
-            "MPRester.xas.search_xas_docs is deprecated. " "Please use MPRester.xas.search instead.",
+            "MPRester.xas.search_xas_docs is deprecated. "
+            "Please use MPRester.xas.search instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -93,7 +94,9 @@ class XASRester(BaseRester[XASDoc]):
             query_params["material_ids"] = ",".join(validate_ids(material_ids))
 
         if sort_fields:
-            query_params.update({"_sort_fields": ",".join([s.strip() for s in sort_fields])})
+            query_params.update(
+                {"_sort_fields": ",".join([s.strip() for s in sort_fields])}
+            )
 
         return super()._search(
             num_chunks=num_chunks,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -44,22 +44,30 @@ ignore_generic = [
 mpr = MPRester()
 
 
-@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
+@pytest.mark.skipif(
+    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
+)
 @pytest.mark.parametrize("rester", mpr._all_resters)
 def test_generic_get_methods(rester):
     # -- Test generic search and get_data_by_id methods
     name = rester.suffix.replace("/", "_")
     if name not in ignore_generic:
         if name not in key_only_resters:
-            doc = rester._query_resource_data({"_limit": 1}, fields=[rester.primary_key])[0]
+            doc = rester._query_resource_data(
+                {"_limit": 1}, fields=[rester.primary_key]
+            )[0]
             assert isinstance(doc, rester.document_model)
 
             if name not in search_only_resters:
-                doc = rester.get_data_by_id(doc.dict()[rester.primary_key], fields=[rester.primary_key])
+                doc = rester.get_data_by_id(
+                    doc.dict()[rester.primary_key], fields=[rester.primary_key]
+                )
                 assert isinstance(doc, rester.document_model)
 
         elif name not in special_resters:
-            doc = rester.get_data_by_id(key_only_resters[name], fields=[rester.primary_key])
+            doc = rester.get_data_by_id(
+                key_only_resters[name], fields=[rester.primary_key]
+            )
             assert isinstance(doc, rester.document_model)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,25 +7,25 @@ from mp_api.client import MPRester
 # -- Rester name data for generic tests
 
 key_only_resters = {
-    "phonon": "mp-11703",
-    "similarity": "mp-149",
+    "materials_phonon": "mp-11703",
+    "materials_similarity": "mp-149",
     "doi": "mp-149",
-    "wulff": "mp-149",
-    "charge_density": "mp-1936745",
-    "provenance": "mp-149",
-    "robocrys": "mp-1025395",
+    "materials_wulff": "mp-149",
+    "materials_charge_density": "mp-1936745",
+    "materials_provenance": "mp-149",
+    "materials_robocrys": "mp-1025395",
 }
 
 search_only_resters = [
-    "grain_boundary",
-    "electronic_structure_bandstructure",
-    "electronic_structure_dos",
-    "substrates",
-    "synthesis",
+    "materials_grain_boundary",
+    "materials_electronic_structure_bandstructure",
+    "materials_electronic_structure_dos",
+    "materials_substrates",
+    "materials_synthesis",
 ]
 
 special_resters = [
-    "charge_density",
+    "materials_charge_density",
 ]
 
 ignore_generic = [
@@ -33,9 +33,9 @@ ignore_generic = [
     "_general_store",
     # "tasks",
     # "bonds",
-    "xas",
-    "elasticity",
-    "fermi",
+    "materials_xas",
+    "materials_elasticity",
+    "materials_fermi",
     # "alloys",
     # "summary",
 ]  # temp
@@ -44,30 +44,22 @@ ignore_generic = [
 mpr = MPRester()
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.environ.get("MP_API_KEY", None) is None, reason="No API key found.")
 @pytest.mark.parametrize("rester", mpr._all_resters)
 def test_generic_get_methods(rester):
     # -- Test generic search and get_data_by_id methods
     name = rester.suffix.replace("/", "_")
     if name not in ignore_generic:
         if name not in key_only_resters:
-            doc = rester._query_resource_data(
-                {"_limit": 1}, fields=[rester.primary_key]
-            )[0]
+            doc = rester._query_resource_data({"_limit": 1}, fields=[rester.primary_key])[0]
             assert isinstance(doc, rester.document_model)
 
             if name not in search_only_resters:
-                doc = rester.get_data_by_id(
-                    doc.dict()[rester.primary_key], fields=[rester.primary_key]
-                )
+                doc = rester.get_data_by_id(doc.dict()[rester.primary_key], fields=[rester.primary_key])
                 assert isinstance(doc, rester.document_model)
 
         elif name not in special_resters:
-            doc = rester.get_data_by_id(
-                key_only_resters[name], fields=[rester.primary_key]
-            )
+            doc = rester.get_data_by_id(key_only_resters[name], fields=[rester.primary_key])
             assert isinstance(doc, rester.document_model)
 
 


### PR DESCRIPTION
This PR adds support for nested materials endpoints in the API. A check has also been added to warn users if their current client version is incompatible with the version of emmet used in the currently deployed API service.