### PR TITLE
replace method post with patch for user setting  

### DIFF
--- a/mp_api/client/routes/_user_settings.py
+++ b/mp_api/client/routes/_user_settings.py
@@ -23,8 +23,21 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
         Raises:
             MPRestError.
         """
-        return self._post_resource(
-            body=settings, params={"consumer_id": consumer_id}
+        body = dict()
+        for key in settings:
+            if key not in [
+                "institution",
+                "sector",
+                "job_role",
+                "is_email_subscribed",
+            ]:
+                raise ValueError(
+                    f"Invalid setting key {key}. Must be one of institution, sector, job_role, is_email_subscribed"
+                )
+            body[f"settings.{key}"] = settings[key]
+        
+        return self._patch_resource(
+            body=body, params={"consumer_id": consumer_id}
         ).get("data")
 
     def patch_user_time_settings(self, consumer_id, time):  # pragma: no cover


### PR DESCRIPTION
Replaced the user setting post method with the patch method. 
The reason for the change is that now we have a `settings.message_last_read` nested field that couldn't be changed manually by the user, and it would make sense to only partially update some fields in the settings. 

