### PR TITLE
use create_user_settings for new users posting settings for the first…

### DIFF
--- a/mp_api/client/routes/_user_settings.py
+++ b/mp_api/client/routes/_user_settings.py
@@ -10,8 +10,22 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
     monty_decode = False
     use_document_model = False
 
-    def set_user_settings(self, consumer_id, settings):  # pragma: no cover
-        """Set user settings.
+    def create_user_settings(self, consumer_id, settings):
+        """Create user settings.
+
+        Args:
+            consumer_id: Consumer ID for the user
+            settings: Dictionary with user settings that
+             use UserSettingsDoc schema
+        Returns:
+            Dictionary with consumer_id and write status.
+        """
+        return self._post_resource(
+            body=settings, params={"consumer_id": consumer_id}
+        ).get("data")
+
+    def patch_user_settings(self, consumer_id, settings):  # pragma: no cover
+        """Patch user settings.
 
         Args:
             consumer_id: Consumer ID for the user
@@ -32,7 +46,8 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
                 "is_email_subscribed",
             ]:
                 raise ValueError(
-                    f"Invalid setting key {key}. Must be one of institution, sector, job_role, is_email_subscribed"
+                    f"Invalid setting key {key}. Must be one of"
+                    "institution, sector, job_role, is_email_subscribed"
                 )
             body[f"settings.{key}"] = settings[key]
 
@@ -41,7 +56,7 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
         )
 
     def patch_user_time_settings(self, consumer_id, time):  # pragma: no cover
-        """Set user settings.
+        """Set user settings last_read_message field.
 
         Args:
             consumer_id: Consumer ID for the user
@@ -53,7 +68,6 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
         Raises:
             MPRestError.
         """
-
         return self._patch_resource(
             body={"settings.message_last_read": time.isoformat()},
             params={"consumer_id": consumer_id},


### PR DESCRIPTION
Added a method for creating user settings that uses post_resource. 
This will work with the web to avoid the situation where new user can't set their settings 