### PR TITLE
Clarify top level get_entries method

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -233,9 +233,7 @@ class MPRester:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")
 
-        if version.parse(emmet_version.base_version) < version.parse(
-            _MAPI_SETTINGS.MIN_EMMET_VERSION
-        ):
+        if version.parse(emmet_version.base_version) < version.parse(_MAPI_SETTINGS.MIN_EMMET_VERSION):
             warnings.warn(
                 "The installed version of the mp-api client may not be compatible with the API server. "
                 "Please install a previous version if any problems occur."
@@ -336,9 +334,7 @@ class MPRester:
 
                 return rester
             else:
-                raise AttributeError(
-                    f"{_self.__class__.__name__!r} object has no attribute {attr!r}"
-                )
+                raise AttributeError(f"{_self.__class__.__name__!r} object has no attribute {attr!r}")
 
         def __materials_getattr__(_self, attr):
             _rester_map = _sub_rester_suffix_map["materials"]
@@ -378,9 +374,7 @@ class MPRester:
             )
             return getattr(super().__getattribute__("materials"), attr)
         else:
-            raise AttributeError(
-                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
-            )
+            raise AttributeError(f"{self.__class__.__name__!r} object has no attribute {attr!r}")
 
     def __getattribute__(self, attr):
         if "molecules" in attr:
@@ -402,13 +396,9 @@ class MPRester:
         :param calc_types: if specified, will restrict to certain task types, e.g. [CalcType.GGA_STATIC]
         :return:
         """
-        tasks = self.materials.get_data_by_id(
-            material_id, fields=["calc_types"]
-        ).calc_types
+        tasks = self.materials.get_data_by_id(material_id, fields=["calc_types"]).calc_types
         if calc_types:
-            return [
-                task for task, calc_type in tasks.items() if calc_type in calc_types
-            ]
+            return [task for task, calc_type in tasks.items() if calc_type in calc_types]
         else:
             return list(tasks.keys())
 
@@ -428,19 +418,14 @@ class MPRester:
         Returns:
             Structure object or list of Structure objects.
         """
-        structure_data = self.materials.get_structure_by_material_id(
-            material_id=material_id, final=final
-        )
+        structure_data = self.materials.get_structure_by_material_id(material_id=material_id, final=final)
 
         if conventional_unit_cell and structure_data:
             if final:
-                structure_data = SpacegroupAnalyzer(
-                    structure_data
-                ).get_conventional_standard_structure()
+                structure_data = SpacegroupAnalyzer(structure_data).get_conventional_standard_structure()
             else:
                 structure_data = [
-                    SpacegroupAnalyzer(structure).get_conventional_standard_structure()
-                    for structure in structure_data
+                    SpacegroupAnalyzer(structure).get_conventional_standard_structure() for structure in structure_data
                 ]
 
         return structure_data
@@ -493,9 +478,7 @@ class MPRester:
         if len(docs) == 1:  # pragma: no cover
             return str(docs[0].material_id)  # type: ignore
         elif len(docs) > 1:  # pragma: no cover
-            raise ValueError(
-                f"Multiple documents return for {task_id}, this should not happen, please report it!"
-            )
+            raise ValueError(f"Multiple documents return for {task_id}, this should not happen, please report it!")
         else:  # pragma: no cover
             warnings.warn(
                 f"No material found containing task {task_id}. Please report it if you suspect a task has gone missing."
@@ -542,9 +525,7 @@ class MPRester:
         Returns:
             List of all materials ids ([MPID])
         """
-        if isinstance(chemsys_formula, list) or (
-            isinstance(chemsys_formula, str) and "-" in chemsys_formula
-        ):
+        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -569,9 +550,7 @@ class MPRester:
         )
         return self.get_material_ids(chemsys_formula)
 
-    def get_structures(
-        self, chemsys_formula: str | list[str], final=True
-    ) -> list[Structure]:
+    def get_structures(self, chemsys_formula: str | list[str], final=True) -> list[Structure]:
         """Get a list of Structures corresponding to a chemical system or formula.
 
         Args:
@@ -583,9 +562,7 @@ class MPRester:
         Returns:
             List of Structure objects. ([Structure])
         """
-        if isinstance(chemsys_formula, list) or (
-            isinstance(chemsys_formula, str) and "-" in chemsys_formula
-        ):
+        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -658,10 +635,10 @@ class MPRester:
         additional_criteria: dict = None,
     ) -> list[ComputedStructureEntry]:
         """Get a list of ComputedEntries or ComputedStructureEntries corresponding
-        to a chemical system or formula.
-
-        Note that by default this returns mixed GGA/GGA+U entries. For others,
-        pass GGA/GGA+U/R2SCAN, or R2SCAN as thermo_types in additional_criteria.
+        to a chemical system or formula. This returns entries for all thermo types
+        represented in the database. Each type corresponds to a different mixing scheme
+        (i.e. GGA/GGA+U, GGA/GGA+U/R2SCAN, R2SCAN). By default the thermo_type of the
+        entry is also returned.
 
         Args:
             chemsys_formula_mpids (str, List[str]): A chemical system, list of chemical systems
@@ -717,7 +694,7 @@ class MPRester:
 
         entries = []
 
-        fields = ["entries"] if not property_data else ["entries"] + property_data
+        fields = ["entries", "thermo_type"] if not property_data else ["entries", "thermo_type"] + property_data
 
         if sort_by_e_above_hull:
             docs = self.thermo.search(
@@ -734,11 +711,7 @@ class MPRester:
             )
 
         for doc in docs:
-            entry_list = (
-                doc.entries.values()
-                if self.use_document_model
-                else doc["entries"].values()
-            )
+            entry_list = doc.entries.values() if self.use_document_model else doc["entries"].values()
             for entry in entry_list:
                 entry_dict = entry.as_dict() if self.monty_decode else entry
                 if not compatible_only:
@@ -748,16 +721,12 @@ class MPRester:
                 if property_data:
                     for property in property_data:
                         entry_dict["data"][property] = (
-                            doc.model_dump()[property]
-                            if self.use_document_model
-                            else doc[property]
+                            doc.model_dump()[property] if self.use_document_model else doc[property]
                         )
 
                 if conventional_unit_cell:
                     entry_struct = Structure.from_dict(entry_dict["structure"])
-                    s = SpacegroupAnalyzer(
-                        entry_struct
-                    ).get_conventional_standard_structure()
+                    s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
                     new_energy = entry_dict["energy"] * site_ratio
 
@@ -772,11 +741,7 @@ class MPRester:
                         if "n_atoms" in correction:
                             correction["n_atoms"] *= site_ratio
 
-                entry = (
-                    ComputedStructureEntry.from_dict(entry_dict)
-                    if self.monty_decode
-                    else entry_dict
-                )
+                entry = ComputedStructureEntry.from_dict(entry_dict) if self.monty_decode else entry_dict
 
                 entries.append(entry)
 
@@ -843,12 +808,8 @@ class MPRester:
         ion_data = self.get_ion_reference_data_for_chemsys(chemsys)
 
         # build the PhaseDiagram for get_ion_entries
-        ion_ref_comps = [
-            Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data
-        ]
-        ion_ref_elts = set(
-            itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
-        )
+        ion_ref_comps = [Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data]
+        ion_ref_elts = set(itertools.chain.from_iterable(i.elements for i in ion_ref_comps))
         # TODO - would be great if the commented line below would work
         # However for some reason you cannot process GibbsComputedStructureEntry with
         # MaterialsProjectAqueousCompatibility
@@ -867,9 +828,7 @@ class MPRester:
             compat = MaterialsProjectAqueousCompatibility(solid_compat=solid_compat)
         # suppress the warning about missing oxidation states
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", message="Failed to guess oxidation states.*"
-            )
+            warnings.filterwarnings("ignore", message="Failed to guess oxidation states.*")
             ion_ref_entries = compat.process_entries(ion_ref_entries)
         # TODO - if the commented line above would work, this conditional block
         # could be removed
@@ -877,32 +836,21 @@ class MPRester:
             # replace the entries with GibbsComputedStructureEntry
             from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
-            ion_ref_entries = GibbsComputedStructureEntry.from_entries(
-                ion_ref_entries, temp=use_gibbs
-            )
+            ion_ref_entries = GibbsComputedStructureEntry.from_entries(ion_ref_entries, temp=use_gibbs)
         ion_ref_pd = PhaseDiagram(ion_ref_entries)
 
         ion_entries = self.get_ion_entries(ion_ref_pd, ion_ref_data=ion_data)
         pbx_entries = [PourbaixEntry(e, f"ion-{n}") for n, e in enumerate(ion_entries)]
 
         # Construct the solid pourbaix entries from filtered ion_ref entries
-        extra_elts = (
-            set(ion_ref_elts)
-            - {Element(s) for s in chemsys}
-            - {Element("H"), Element("O")}
-        )
+        extra_elts = set(ion_ref_elts) - {Element(s) for s in chemsys} - {Element("H"), Element("O")}
         for entry in ion_ref_entries:
             entry_elts = set(entry.composition.elements)
             # Ensure no OH chemsys or extraneous elements from ion references
-            if not (
-                entry_elts <= {Element("H"), Element("O")}
-                or extra_elts.intersection(entry_elts)
-            ):
+            if not (entry_elts <= {Element("H"), Element("O")} or extra_elts.intersection(entry_elts)):
                 # Create new computed entry
                 form_e = ion_ref_pd.get_form_energy(entry)
-                new_entry = ComputedEntry(
-                    entry.composition, form_e, entry_id=entry.entry_id
-                )
+                new_entry = ComputedEntry(entry.composition, form_e, entry_id=entry.entry_id)
                 pbx_entry = PourbaixEntry(new_entry)
                 pbx_entries.append(pbx_entry)
 
@@ -982,9 +930,7 @@ class MPRester:
             chemsys = chemsys.split("-")
         return [d for d in ion_data if d["data"]["MajElements"] in chemsys]
 
-    def get_ion_entries(
-        self, pd: PhaseDiagram, ion_ref_data: list[dict] = None
-    ) -> list[IonEntry]:
+    def get_ion_entries(self, pd: PhaseDiagram, ion_ref_data: list[dict] = None) -> list[IonEntry]:
         """Retrieve IonEntry objects that can be used in the construction of
         Pourbaix Diagrams. The energies of the IonEntry are calculaterd from
         the solid energies in the provided Phase Diagram to be
@@ -1017,8 +963,7 @@ class MPRester:
         # raise ValueError if O and H not in chemsys
         if "O" not in chemsys or "H" not in chemsys:
             raise ValueError(
-                "The phase diagram chemical system must contain O and H! Your"
-                f" diagram chemical system is {chemsys}."
+                "The phase diagram chemical system must contain O and H! Your" f" diagram chemical system is {chemsys}."
             )
 
         if not ion_ref_data:
@@ -1030,11 +975,7 @@ class MPRester:
         ion_entries = []
         for _n, i_d in enumerate(ion_data):
             ion = Ion.from_formula(i_d["formula"])
-            refs = [
-                e
-                for e in pd.all_entries
-                if e.composition.reduced_formula == i_d["data"]["RefSolid"]
-            ]
+            refs = [e for e in pd.all_entries if e.composition.reduced_formula == i_d["data"]["RefSolid"]]
             if not refs:
                 raise ValueError("Reference solid not contained in entry list")
             stable_ref = sorted(refs, key=lambda x: x.energy_per_atom)[0]
@@ -1049,9 +990,7 @@ class MPRester:
                 # convert to eV/formula unit
                 ref_solid_energy = i_d["data"]["ΔGᶠRefSolid"]["value"] / 96485
             else:
-                raise ValueError(
-                    f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}"
-                )
+                raise ValueError(f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}")
             solid_diff = pd.get_form_energy(stable_ref) - ref_solid_energy * rf
             elt = i_d["data"]["MajElements"]
             correction_factor = ion.composition[elt] / stable_ref.composition[elt]
@@ -1064,9 +1003,7 @@ class MPRester:
                 # convert to eV/formula unit
                 ion_free_energy = i_d["data"]["ΔGᶠ"]["value"] / 96485
             else:
-                raise ValueError(
-                    f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}"
-                )
+                raise ValueError(f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}")
             energy = ion_free_energy + solid_diff * correction_factor
             ion_entries.append(IonEntry(ion, energy))
 
@@ -1185,8 +1122,7 @@ class MPRester:
                 inc_structure=inc_structure,
                 property_data=property_data,
                 conventional_unit_cell=conventional_unit_cell,
-                additional_criteria=additional_criteria
-                or {"thermo_types": ["GGA_GGA+U"]},
+                additional_criteria=additional_criteria or {"thermo_types": ["GGA_GGA+U"]},
             )
         )
 
@@ -1272,12 +1208,8 @@ class MPRester:
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
         structure = self.get_structure_by_material_id(material_id)
-        surfaces = surfaces = self.surface_properties.get_data_by_id(
-            material_id
-        ).surfaces
-        lattice = (
-            SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
-        )
+        surfaces = surfaces = self.surface_properties.get_data_by_id(material_id).surfaces
+        lattice = SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
         miller_energy_map = {}
         for surf in surfaces:
             miller = tuple(surf.miller_index)
@@ -1287,9 +1219,7 @@ class MPRester:
         millers, energies = zip(*miller_energy_map.items())
         return WulffShape(lattice, millers, energies)
 
-    def get_charge_density_from_material_id(
-        self, material_id: str, inc_task_doc: bool = False
-    ) -> Chgcar | None:
+    def get_charge_density_from_material_id(self, material_id: str, inc_task_doc: bool = False) -> Chgcar | None:
         """Get charge density data for a given Materials Project ID.
 
         Arguments:
@@ -1300,10 +1230,7 @@ class MPRester:
             chgcar: Pymatgen Chgcar object.
         """
         if not hasattr(self, "charge_density"):
-            raise MPRestError(
-                "boto3 not installed. "
-                "To query charge density data install the boto3 package."
-            )
+            raise MPRestError("boto3 not installed. " "To query charge density data install the boto3 package.")
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity
@@ -1350,11 +1277,7 @@ class MPRester:
             metadata info, e.g. the task/external_ids that belong to a directory.
         """
         # task_id's correspond to NoMaD external_id's
-        calc_types = (
-            [t.value for t in calc_types if isinstance(t, CalcType)]
-            if calc_types
-            else []
-        )
+        calc_types = [t.value for t in calc_types if isinstance(t, CalcType)] if calc_types else []
 
         meta = {}
         for doc in self.materials.search(
@@ -1384,13 +1307,9 @@ class MPRester:
         prefix += "external_id="
 
         task_ids = [t["task_id"] for tl in meta.values() for t in tl]
-        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(
-            prefix=prefix, task_ids=task_ids
-        )
+        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(prefix=prefix, task_ids=task_ids)
         if len(nomad_exist_task_ids) != len(task_ids):
-            self._print_help_message(
-                nomad_exist_task_ids, task_ids, file_patterns, calc_types
-            )
+            self._print_help_message(nomad_exist_task_ids, task_ids, file_patterns, calc_types)
 
         # generate download links for those that exist
         prefix = "https://nomad-lab.eu/prod/rae/api/raw/query?"

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -233,7 +233,9 @@ class MPRester:
             self.contribs = None
             warnings.warn(f"Problem loading MPContribs client: {error}")
 
-        if version.parse(emmet_version.base_version) < version.parse(_MAPI_SETTINGS.MIN_EMMET_VERSION):
+        if version.parse(emmet_version.base_version) < version.parse(
+            _MAPI_SETTINGS.MIN_EMMET_VERSION
+        ):
             warnings.warn(
                 "The installed version of the mp-api client may not be compatible with the API server. "
                 "Please install a previous version if any problems occur."
@@ -334,7 +336,9 @@ class MPRester:
 
                 return rester
             else:
-                raise AttributeError(f"{_self.__class__.__name__!r} object has no attribute {attr!r}")
+                raise AttributeError(
+                    f"{_self.__class__.__name__!r} object has no attribute {attr!r}"
+                )
 
         def __materials_getattr__(_self, attr):
             _rester_map = _sub_rester_suffix_map["materials"]
@@ -374,7 +378,9 @@ class MPRester:
             )
             return getattr(super().__getattribute__("materials"), attr)
         else:
-            raise AttributeError(f"{self.__class__.__name__!r} object has no attribute {attr!r}")
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
+            )
 
     def __getattribute__(self, attr):
         if "molecules" in attr:
@@ -396,9 +402,13 @@ class MPRester:
         :param calc_types: if specified, will restrict to certain task types, e.g. [CalcType.GGA_STATIC]
         :return:
         """
-        tasks = self.materials.get_data_by_id(material_id, fields=["calc_types"]).calc_types
+        tasks = self.materials.get_data_by_id(
+            material_id, fields=["calc_types"]
+        ).calc_types
         if calc_types:
-            return [task for task, calc_type in tasks.items() if calc_type in calc_types]
+            return [
+                task for task, calc_type in tasks.items() if calc_type in calc_types
+            ]
         else:
             return list(tasks.keys())
 
@@ -418,14 +428,19 @@ class MPRester:
         Returns:
             Structure object or list of Structure objects.
         """
-        structure_data = self.materials.get_structure_by_material_id(material_id=material_id, final=final)
+        structure_data = self.materials.get_structure_by_material_id(
+            material_id=material_id, final=final
+        )
 
         if conventional_unit_cell and structure_data:
             if final:
-                structure_data = SpacegroupAnalyzer(structure_data).get_conventional_standard_structure()
+                structure_data = SpacegroupAnalyzer(
+                    structure_data
+                ).get_conventional_standard_structure()
             else:
                 structure_data = [
-                    SpacegroupAnalyzer(structure).get_conventional_standard_structure() for structure in structure_data
+                    SpacegroupAnalyzer(structure).get_conventional_standard_structure()
+                    for structure in structure_data
                 ]
 
         return structure_data
@@ -478,7 +493,9 @@ class MPRester:
         if len(docs) == 1:  # pragma: no cover
             return str(docs[0].material_id)  # type: ignore
         elif len(docs) > 1:  # pragma: no cover
-            raise ValueError(f"Multiple documents return for {task_id}, this should not happen, please report it!")
+            raise ValueError(
+                f"Multiple documents return for {task_id}, this should not happen, please report it!"
+            )
         else:  # pragma: no cover
             warnings.warn(
                 f"No material found containing task {task_id}. Please report it if you suspect a task has gone missing."
@@ -525,7 +542,9 @@ class MPRester:
         Returns:
             List of all materials ids ([MPID])
         """
-        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
+        if isinstance(chemsys_formula, list) or (
+            isinstance(chemsys_formula, str) and "-" in chemsys_formula
+        ):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -550,7 +569,9 @@ class MPRester:
         )
         return self.get_material_ids(chemsys_formula)
 
-    def get_structures(self, chemsys_formula: str | list[str], final=True) -> list[Structure]:
+    def get_structures(
+        self, chemsys_formula: str | list[str], final=True
+    ) -> list[Structure]:
         """Get a list of Structures corresponding to a chemical system or formula.
 
         Args:
@@ -562,7 +583,9 @@ class MPRester:
         Returns:
             List of Structure objects. ([Structure])
         """
-        if isinstance(chemsys_formula, list) or (isinstance(chemsys_formula, str) and "-" in chemsys_formula):
+        if isinstance(chemsys_formula, list) or (
+            isinstance(chemsys_formula, str) and "-" in chemsys_formula
+        ):
             input_params = {"chemsys": chemsys_formula}
         else:
             input_params = {"formula": chemsys_formula}
@@ -694,7 +717,11 @@ class MPRester:
 
         entries = []
 
-        fields = ["entries", "thermo_type"] if not property_data else ["entries", "thermo_type"] + property_data
+        fields = (
+            ["entries", "thermo_type"]
+            if not property_data
+            else ["entries", "thermo_type"] + property_data
+        )
 
         if sort_by_e_above_hull:
             docs = self.thermo.search(
@@ -711,7 +738,11 @@ class MPRester:
             )
 
         for doc in docs:
-            entry_list = doc.entries.values() if self.use_document_model else doc["entries"].values()
+            entry_list = (
+                doc.entries.values()
+                if self.use_document_model
+                else doc["entries"].values()
+            )
             for entry in entry_list:
                 entry_dict = entry.as_dict() if self.monty_decode else entry
                 if not compatible_only:
@@ -721,12 +752,16 @@ class MPRester:
                 if property_data:
                     for property in property_data:
                         entry_dict["data"][property] = (
-                            doc.model_dump()[property] if self.use_document_model else doc[property]
+                            doc.model_dump()[property]
+                            if self.use_document_model
+                            else doc[property]
                         )
 
                 if conventional_unit_cell:
                     entry_struct = Structure.from_dict(entry_dict["structure"])
-                    s = SpacegroupAnalyzer(entry_struct).get_conventional_standard_structure()
+                    s = SpacegroupAnalyzer(
+                        entry_struct
+                    ).get_conventional_standard_structure()
                     site_ratio = len(s) / len(entry_struct)
                     new_energy = entry_dict["energy"] * site_ratio
 
@@ -741,7 +776,11 @@ class MPRester:
                         if "n_atoms" in correction:
                             correction["n_atoms"] *= site_ratio
 
-                entry = ComputedStructureEntry.from_dict(entry_dict) if self.monty_decode else entry_dict
+                entry = (
+                    ComputedStructureEntry.from_dict(entry_dict)
+                    if self.monty_decode
+                    else entry_dict
+                )
 
                 entries.append(entry)
 
@@ -808,8 +847,12 @@ class MPRester:
         ion_data = self.get_ion_reference_data_for_chemsys(chemsys)
 
         # build the PhaseDiagram for get_ion_entries
-        ion_ref_comps = [Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data]
-        ion_ref_elts = set(itertools.chain.from_iterable(i.elements for i in ion_ref_comps))
+        ion_ref_comps = [
+            Ion.from_formula(d["data"]["RefSolid"]).composition for d in ion_data
+        ]
+        ion_ref_elts = set(
+            itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
+        )
         # TODO - would be great if the commented line below would work
         # However for some reason you cannot process GibbsComputedStructureEntry with
         # MaterialsProjectAqueousCompatibility
@@ -828,7 +871,9 @@ class MPRester:
             compat = MaterialsProjectAqueousCompatibility(solid_compat=solid_compat)
         # suppress the warning about missing oxidation states
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Failed to guess oxidation states.*")
+            warnings.filterwarnings(
+                "ignore", message="Failed to guess oxidation states.*"
+            )
             ion_ref_entries = compat.process_entries(ion_ref_entries)
         # TODO - if the commented line above would work, this conditional block
         # could be removed
@@ -836,21 +881,32 @@ class MPRester:
             # replace the entries with GibbsComputedStructureEntry
             from pymatgen.entries.computed_entries import GibbsComputedStructureEntry
 
-            ion_ref_entries = GibbsComputedStructureEntry.from_entries(ion_ref_entries, temp=use_gibbs)
+            ion_ref_entries = GibbsComputedStructureEntry.from_entries(
+                ion_ref_entries, temp=use_gibbs
+            )
         ion_ref_pd = PhaseDiagram(ion_ref_entries)
 
         ion_entries = self.get_ion_entries(ion_ref_pd, ion_ref_data=ion_data)
         pbx_entries = [PourbaixEntry(e, f"ion-{n}") for n, e in enumerate(ion_entries)]
 
         # Construct the solid pourbaix entries from filtered ion_ref entries
-        extra_elts = set(ion_ref_elts) - {Element(s) for s in chemsys} - {Element("H"), Element("O")}
+        extra_elts = (
+            set(ion_ref_elts)
+            - {Element(s) for s in chemsys}
+            - {Element("H"), Element("O")}
+        )
         for entry in ion_ref_entries:
             entry_elts = set(entry.composition.elements)
             # Ensure no OH chemsys or extraneous elements from ion references
-            if not (entry_elts <= {Element("H"), Element("O")} or extra_elts.intersection(entry_elts)):
+            if not (
+                entry_elts <= {Element("H"), Element("O")}
+                or extra_elts.intersection(entry_elts)
+            ):
                 # Create new computed entry
                 form_e = ion_ref_pd.get_form_energy(entry)
-                new_entry = ComputedEntry(entry.composition, form_e, entry_id=entry.entry_id)
+                new_entry = ComputedEntry(
+                    entry.composition, form_e, entry_id=entry.entry_id
+                )
                 pbx_entry = PourbaixEntry(new_entry)
                 pbx_entries.append(pbx_entry)
 
@@ -930,7 +986,9 @@ class MPRester:
             chemsys = chemsys.split("-")
         return [d for d in ion_data if d["data"]["MajElements"] in chemsys]
 
-    def get_ion_entries(self, pd: PhaseDiagram, ion_ref_data: list[dict] = None) -> list[IonEntry]:
+    def get_ion_entries(
+        self, pd: PhaseDiagram, ion_ref_data: list[dict] = None
+    ) -> list[IonEntry]:
         """Retrieve IonEntry objects that can be used in the construction of
         Pourbaix Diagrams. The energies of the IonEntry are calculaterd from
         the solid energies in the provided Phase Diagram to be
@@ -963,7 +1021,8 @@ class MPRester:
         # raise ValueError if O and H not in chemsys
         if "O" not in chemsys or "H" not in chemsys:
             raise ValueError(
-                "The phase diagram chemical system must contain O and H! Your" f" diagram chemical system is {chemsys}."
+                "The phase diagram chemical system must contain O and H! Your"
+                f" diagram chemical system is {chemsys}."
             )
 
         if not ion_ref_data:
@@ -975,7 +1034,11 @@ class MPRester:
         ion_entries = []
         for _n, i_d in enumerate(ion_data):
             ion = Ion.from_formula(i_d["formula"])
-            refs = [e for e in pd.all_entries if e.composition.reduced_formula == i_d["data"]["RefSolid"]]
+            refs = [
+                e
+                for e in pd.all_entries
+                if e.composition.reduced_formula == i_d["data"]["RefSolid"]
+            ]
             if not refs:
                 raise ValueError("Reference solid not contained in entry list")
             stable_ref = sorted(refs, key=lambda x: x.energy_per_atom)[0]
@@ -990,7 +1053,9 @@ class MPRester:
                 # convert to eV/formula unit
                 ref_solid_energy = i_d["data"]["ΔGᶠRefSolid"]["value"] / 96485
             else:
-                raise ValueError(f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}")
+                raise ValueError(
+                    f"Ion reference solid energy has incorrect unit {i_d['data']['ΔGᶠRefSolid']['unit']}"
+                )
             solid_diff = pd.get_form_energy(stable_ref) - ref_solid_energy * rf
             elt = i_d["data"]["MajElements"]
             correction_factor = ion.composition[elt] / stable_ref.composition[elt]
@@ -1003,7 +1068,9 @@ class MPRester:
                 # convert to eV/formula unit
                 ion_free_energy = i_d["data"]["ΔGᶠ"]["value"] / 96485
             else:
-                raise ValueError(f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}")
+                raise ValueError(
+                    f"Ion free energy has incorrect unit {i_d['data']['ΔGᶠ']['unit']}"
+                )
             energy = ion_free_energy + solid_diff * correction_factor
             ion_entries.append(IonEntry(ion, energy))
 
@@ -1122,7 +1189,8 @@ class MPRester:
                 inc_structure=inc_structure,
                 property_data=property_data,
                 conventional_unit_cell=conventional_unit_cell,
-                additional_criteria=additional_criteria or {"thermo_types": ["GGA_GGA+U"]},
+                additional_criteria=additional_criteria
+                or {"thermo_types": ["GGA_GGA+U"]},
             )
         )
 
@@ -1208,8 +1276,12 @@ class MPRester:
         from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
         structure = self.get_structure_by_material_id(material_id)
-        surfaces = surfaces = self.surface_properties.get_data_by_id(material_id).surfaces
-        lattice = SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
+        surfaces = surfaces = self.surface_properties.get_data_by_id(
+            material_id
+        ).surfaces
+        lattice = (
+            SpacegroupAnalyzer(structure).get_conventional_standard_structure().lattice
+        )
         miller_energy_map = {}
         for surf in surfaces:
             miller = tuple(surf.miller_index)
@@ -1219,7 +1291,9 @@ class MPRester:
         millers, energies = zip(*miller_energy_map.items())
         return WulffShape(lattice, millers, energies)
 
-    def get_charge_density_from_material_id(self, material_id: str, inc_task_doc: bool = False) -> Chgcar | None:
+    def get_charge_density_from_material_id(
+        self, material_id: str, inc_task_doc: bool = False
+    ) -> Chgcar | None:
         """Get charge density data for a given Materials Project ID.
 
         Arguments:
@@ -1230,7 +1304,10 @@ class MPRester:
             chgcar: Pymatgen Chgcar object.
         """
         if not hasattr(self, "charge_density"):
-            raise MPRestError("boto3 not installed. " "To query charge density data install the boto3 package.")
+            raise MPRestError(
+                "boto3 not installed. "
+                "To query charge density data install the boto3 package."
+            )
 
         # TODO: really we want a recommended task_id for charge densities here
         # this could potentially introduce an ambiguity
@@ -1277,7 +1354,11 @@ class MPRester:
             metadata info, e.g. the task/external_ids that belong to a directory.
         """
         # task_id's correspond to NoMaD external_id's
-        calc_types = [t.value for t in calc_types if isinstance(t, CalcType)] if calc_types else []
+        calc_types = (
+            [t.value for t in calc_types if isinstance(t, CalcType)]
+            if calc_types
+            else []
+        )
 
         meta = {}
         for doc in self.materials.search(
@@ -1307,9 +1388,13 @@ class MPRester:
         prefix += "external_id="
 
         task_ids = [t["task_id"] for tl in meta.values() for t in tl]
-        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(prefix=prefix, task_ids=task_ids)
+        nomad_exist_task_ids = self._check_get_download_info_url_by_task_id(
+            prefix=prefix, task_ids=task_ids
+        )
         if len(nomad_exist_task_ids) != len(task_ids):
-            self._print_help_message(nomad_exist_task_ids, task_ids, file_patterns, calc_types)
+            self._print_help_message(
+                nomad_exist_task_ids, task_ids, file_patterns, calc_types
+            )
 
         # generate download links for those that exist
         prefix = "https://nomad-lab.eu/prod/rae/api/raw/query?"


### PR DESCRIPTION
Clarifies the top level `get_entries` method to avoid confusion with what looks like multiple entries for a single `material_id`. Relevant issue: https://github.com/materialsproject/api/issues/841