### PR TITLE
patch agreed_terms field for user settings

### DIFF
--- a/mp_api/client/routes/_user_settings.py
+++ b/mp_api/client/routes/_user_settings.py
@@ -46,10 +46,11 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
                 "sector",
                 "job_role",
                 "is_email_subscribed",
+		"agreed_terms"
             ]:
                 raise ValueError(
                     f"Invalid setting key {key}. Must be one of"
-                    "institution, sector, job_role, is_email_subscribed"
+                    "institution, sector, job_role, is_email_subscribed, agreed_terms"
                 )
             body[f"settings.{key}"] = settings[key]
 

--- a/mp_api/client/routes/_user_settings.py
+++ b/mp_api/client/routes/_user_settings.py
@@ -46,7 +46,7 @@ class UserSettingsRester(BaseRester[UserSettingsDoc]):  # pragma: no cover
                 "sector",
                 "job_role",
                 "is_email_subscribed",
-		"agreed_terms"
+                "agreed_terms",
             ]:
                 raise ValueError(
                     f"Invalid setting key {key}. Must be one of"


### PR DESCRIPTION
## Summary

Added terms agreement field to the patch method for user settings.  
This will need to go out along with the front-end changes for checking our latest terms. 
By clicking the box on our website, it will patch an additional data field to our consumer store. 