### PR TITLE
Read API key from `pymatgen` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,24 +6,24 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.0.292
     hooks:
       - id: ruff
         args: [--fix, --show-fixes]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: "1.15.0"
+    rev: "1.16.0"
     hooks:
       - id: blacken-docs
         additional_dependencies: [black>=23.7.0]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-case-conflict
       - id: check-symlinks
@@ -34,7 +34,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.6
     hooks:
       - id: codespell
         stages: [commit, commit-msg]

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -15,7 +15,7 @@ from emmet.core.vasp.calc_types import CalcType
 from packaging import version
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry
-from pymatgen.core import Element, Structure
+from pymatgen.core import SETTINGS, Element, Structure
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedStructureEntry
 from pymatgen.io.vasp import Chgcar
@@ -165,6 +165,9 @@ class MPRester:
         headers (dict): Custom headers for localhost connections.
         mute_progress_bars (bool): Whether to mute progress bars.
         """
+        # SETTINGS tries to read API key from ~/.config/.pmgrc.yaml
+        api_key = api_key or DEFAULT_API_KEY or SETTINGS.get("PMG_MAPI_KEY")
+
         if api_key and len(api_key) != 32:
             raise ValueError(
                 "Please use a new API key from https://materialsproject.org/api "
@@ -172,7 +175,7 @@ class MPRester:
                 "API are 16 characters."
             )
 
-        self.api_key = api_key or DEFAULT_API_KEY
+        self.api_key = api_key
         self.endpoint = endpoint
         self.headers = headers or {}
         self.session = session or BaseRester._create_session(

--- a/mp_api/client/routes/materials/substrates.py
+++ b/mp_api/client/routes/materials/substrates.py
@@ -42,7 +42,7 @@ class SubstratesRester(BaseRester[SubstratesDoc]):
         """Query equations of state docs using a variety of search criteria.
 
         Arguments:
-            area (Tuple[float,float]): Minimum and maximum volume in Å² to consider for the minimim coincident
+            area (Tuple[float,float]): Minimum and maximum volume in Å² to consider for the minimum coincident
                 interface area range.
             energy (Tuple[float,float]): Minimum and maximum energy in meV to consider for the elastic energy range.
             film_id (str): Materials Project ID of the film material.

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -324,8 +324,11 @@ class TestMPRester:
         assert len(docs) == 15000
 
 
-def test_pmg_api_key(monkeypatch):
+def test_pmg_api_key(monkeypatch: pytest.MonkeyPatch):
     from pymatgen.core import SETTINGS
+
+    # unset env var MP_API_KEY
+    monkeypatch.delenv("MP_API_KEY", raising=False)
 
     fake_api_key = "12345678901234567890123456789012"  # 32 chars
     # patch pymatgen.core.SETTINGS to contain PMG_MAPI_KEY

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -68,14 +68,14 @@ class TestMPRester:
         assert len(data) > 5
 
     def test_get_materials_ids_doc(self, mpr):
-        mpids = mpr.get_materials_ids("Al2O3")
-        random.shuffle(mpids)
-        doc = mpr.materials.get_data_by_id(mpids.pop(0))
+        mp_ids = mpr.get_materials_ids("Al2O3")
+        random.shuffle(mp_ids)
+        doc = mpr.materials.get_data_by_id(mp_ids.pop(0))
         assert doc.formula_pretty == "Al2O3"
 
-        mpids = mpr.get_materials_ids("Al-O")
-        random.shuffle(mpids)
-        doc = mpr.materials.get_data_by_id(mpids.pop(0))
+        mp_ids = mpr.get_materials_ids("Al-O")
+        random.shuffle(mp_ids)
+        doc = mpr.materials.get_data_by_id(mp_ids.pop(0))
         assert doc.chemsys == "Al-O"
 
     def test_get_structures(self, mpr):
@@ -99,9 +99,9 @@ class TestMPRester:
     def test_get_bandstructure_by_material_id(self, mpr):
         bs = mpr.get_bandstructure_by_material_id("mp-149")
         assert isinstance(bs, BandStructureSymmLine)
-        bs_unif = mpr.get_bandstructure_by_material_id("mp-149", line_mode=False)
-        assert isinstance(bs_unif, BandStructure)
-        assert not isinstance(bs_unif, BandStructureSymmLine)
+        bs_uniform = mpr.get_bandstructure_by_material_id("mp-149", line_mode=False)
+        assert isinstance(bs_uniform, BandStructure)
+        assert not isinstance(bs_uniform, BandStructureSymmLine)
 
     def test_get_dos_by_id(self, mpr):
         dos = mpr.get_dos_by_material_id("mp-149")
@@ -322,3 +322,14 @@ class TestMPRester:
         ]
         docs = mpr.summary.search(material_ids=mpids, fields=["material_ids"])
         assert len(docs) == 15000
+
+
+def test_pmg_api_key(monkeypatch):
+    from pymatgen.core import SETTINGS
+
+    fake_api_key = "12345678901234567890123456789012"  # 32 chars
+    # patch pymatgen.core.SETTINGS to contain PMG_MAPI_KEY
+    monkeypatch.setitem(SETTINGS, "PMG_MAPI_KEY", fake_api_key)
+
+    # create MPRester and check that it picked up the API key from pymatgen SETTINGS
+    assert MPRester().api_key == fake_api_key

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -26,6 +26,8 @@ from pymatgen.phonon.dos import PhononDos
 from mp_api.client import MPRester
 from mp_api.client.core.settings import MAPIClientSettings
 
+os.environ["MP_API_KEY"] = "test"
+
 
 @pytest.fixture()
 def mpr():
@@ -327,8 +329,8 @@ class TestMPRester:
 def test_pmg_api_key(monkeypatch: pytest.MonkeyPatch):
     from pymatgen.core import SETTINGS
 
-    # unset env var MP_API_KEY
-    monkeypatch.delenv("MP_API_KEY", raising=False)
+    # unset DEFAULT_API_KEY
+    monkeypatch.setattr("mp_api.client.mprester.DEFAULT_API_KEY", None)
 
     fake_api_key = "12345678901234567890123456789012"  # 32 chars
     # patch pymatgen.core.SETTINGS to contain PMG_MAPI_KEY

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -270,7 +270,7 @@ class TestMPRester:
             itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
         )
         ion_ref_entries = mpr.get_entries_in_chemsys(
-            list([str(e) for e in ion_ref_elts] + ["O", "H"])
+            [*map(str, ion_ref_elts), "O", "H"]
         )
         mpc = MaterialsProjectAqueousCompatibility()
         ion_ref_entries = mpc.process_entries(ion_ref_entries)


### PR DESCRIPTION
Brings behavior more in line with legacy rester in `pymatgen.ext.matproj` which looks for API key in `~/.config/.pmgrc.yaml` if not passed explicitly.