### PR TITLE
[WIP] Add convenience method for obtaining blessed calculation for different functionals

### DIFF
--- a/mp_api/client/routes/materials/materials.py
+++ b/mp_api/client/routes/materials/materials.py
@@ -365,8 +365,8 @@ class MaterialsRester(BaseRester):
 
             query_params.update(
                 {
-                    "uncorrected_energy_min": uncorrected_energy[0],
-                    "uncorrected_energy_max": uncorrected_energy[1],
+                    "energy_min": uncorrected_energy[0],
+                    "energy_max": uncorrected_energy[1],
                 }
             )
 

--- a/tests/client/materials/test_materials.py
+++ b/tests/client/materials/test_materials.py
@@ -62,3 +62,24 @@ def test_client(rester):
         custom_field_tests=custom_field_tests,
         sub_doc_fields=sub_doc_fields,
     )
+
+
+@pytest.mark.xfail(condition=True, reason="Needs new deployment.", strict=False)
+@pytest.mark.parametrize(
+    "run_type, uncorrected_energy, use_document_model",
+    [("PBE", None, True), ("r2SCAN", 1.0, False), ("GGA_U", (-50e4, 0.0), True)],
+)
+def test_blessed_entry(run_type, uncorrected_energy, use_document_model):
+    # Si and NiO. Si has GGA and r2SCAN entries, NiO has GGA, GGA+U, and r2SCAN
+    with MaterialsRester(use_document_model=use_document_model) as rester:
+        blessed = rester.get_blessed_entries(
+            run_type,
+            material_ids=["mp-149", "mp-19009"],
+            uncorrected_energy=uncorrected_energy,
+        )
+
+    assert all(
+        isinstance(entry, dict)
+        and all(entry.get(k) is not None for k in ("material_id", "blessed_entry"))
+        for entry in blessed
+    )


### PR DESCRIPTION
## Summary
- Convenience function added to `MaterialsRester` for obtaining blessed calculation entries for different functionals

## Todos
- Add additional function parameters to query structure metadata fields [shown here.](https://api.materialsproject.org/docs#/Materials/search_materials_core_blessed_tasks__get)
- Add ability to ask for full task document alongside each returned `ComputedStructureEntry`
- Add top level convenience function to `MPRester`

**NOTE: This requires one last deployment of the API service to fix pagination.