### PR TITLE
Adjust pymatgen pin to allow newer versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "setuptools",
   "msgpack",
   "maggma>=0.57.1",
-  "pymatgen>=2022.3.7,<2024.2.20",
+  "pymatgen>=2022.3.7,!=2024.2.20",
   "typing-extensions>=3.7.4.1",
   "requests>=2.23.0",
   "monty>=2023.9.25",


### PR DESCRIPTION
See discussion in #887.

This releases the pin on pymatgen to allow newer versions to be installed.

Closes #887.