### PR TITLE
Remove deprecated arg from robocrys search

### DIFF
--- a/mp_api/client/routes/materials/robocrys.py
+++ b/mp_api/client/routes/materials/robocrys.py
@@ -45,7 +45,6 @@ class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
     def search_docs(
         self,
         material_ids: str | list[str] | None = None,
-        deprecated: bool | None = False,
         num_chunks: int | None = None,
         chunk_size: int = 1000,
         all_fields: bool = True,
@@ -56,7 +55,6 @@ class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
         Arguments:
             material_ids (str, List[str]): A single Material ID string or list of strings
                 (e.g., mp-149, [mp-149, mp-13]).
-            deprecated (bool): Whether the material is tagged as deprecated.
             num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.
             chunk_size (int): Number of data entries per chunk.
             all_fields (bool): Whether to return all fields in the document. Defaults to True.
@@ -66,7 +64,7 @@ class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
         Returns:
             ([RobocrystallogapherDoc], [dict]) List of robocrystallographer documents or dictionaries.
         """
-        query_params = {"deprecated": deprecated}  # type: dict
+        query_params = {}  # type: dict
 
         if material_ids:
             if isinstance(material_ids, str):


### PR DESCRIPTION
Fixes generic robocrys document queries by removing deprecated query argument.