### PR TITLE
Add MPRester.get_charge_density_from_task_id()

### DIFF
--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -292,13 +292,22 @@ class TestMPRester:
         dos = mpr.get_phonon_dos_by_material_id("mp-2172")
         assert isinstance(dos, PhononDos)
 
-    # @pytest.mark.skip(reason="Test needs fixing with ENV variables")
-    def test_get_charge_density_data(self, mpr):
+    def test_get_charge_density_from_material_id(self, mpr):
         chgcar = mpr.get_charge_density_from_material_id("mp-149")
         assert isinstance(chgcar, Chgcar)
 
         chgcar, task_doc = mpr.get_charge_density_from_material_id(
             "mp-149", inc_task_doc=True
+        )
+        assert isinstance(chgcar, Chgcar)
+        assert isinstance(task_doc, TaskDoc)
+
+    def test_get_charge_density_from_task_id(self, mpr):
+        chgcar = mpr.get_charge_density_from_task_id("mp-2246557")
+        assert isinstance(chgcar, Chgcar)
+
+        chgcar, task_doc = mpr.get_charge_density_from_task_id(
+            "mp-2246557", inc_task_doc=True
         )
         assert isinstance(chgcar, Chgcar)
         assert isinstance(task_doc, TaskDoc)


### PR DESCRIPTION
## Summary

Fixes #924

Major changes:

- Added `MPRester.get_charge_density_from_task_id()` to obtain charge densities from task id

## Todos

Note that the `test_get_charge_density_from_material_id()` is currently failing, and was failing independently of this PR. This is due to an issue in emmet from [task.search](https://github.com/materialsproject/api/blob/main/mp_api/client/mprester.py#L1334):

```
    def model_post_init(self, __context: Any) -> None:
        # Always refresh task_type, calc_type, run_type
        # See, e.g. https://github.com/materialsproject/emmet/issues/960
        # where run_type's were set incorrectly in older versions of TaskDoc
    
        # To determine task and run type, we search for input sets in this order
        # of precedence: calcs_reversed, inputs, orig_inputs
>       for inp_set in [self.calcs_reversed[0].input, self.input, self.orig_inputs]:
E       TypeError: 'NoneType' object is not subscriptable

venv/lib/python3.10/site-packages/emmet/core/tasks.py:453: TypeError
```

Should be reproducible with:

```
python -m pytest tests/test_mprester.py -k test_get_charge_density_data
```

on `main` branch. 

I can submit a separate issue for this if you'd like, but otherwise the code should function identically, with the relevant parts moved to `get_charge_density_from_task_id()`


## Checklist

- [X] Google format doc strings added. Check with `ruff`.
- [X] Type annotations included. Check with `mypy`.
- [X] Tests added for new features/fixes.

