### PR TITLE
`MPRester` lazily get `endpoint` and `api_key`  

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Format API key name (Linux/MacOS)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
-          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
+          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) },,} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
 
       - name: Format API key name (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) },,} | awk '{gsub(/-|\./, "_"); print}')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Test with pytest
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     strategy:
       max-parallel: 2
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.11"]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,6 @@ jobs:
   test:
     strategy:
       max-parallel: 2
-      fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.11"]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,12 +46,12 @@ jobs:
       - name: Format API key name (Linux/MacOS)
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
-          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) },,} | awk '{gsub(/-|\./, "_"); print}')" >> $GITHUB_ENV
+          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}' | tr '[:lower:]' '[:upper:]')" >> $GITHUB_ENV
 
       - name: Format API key name (Windows)
         if: matrix.os == 'windows-latest'
         run: |
-          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) },,} | awk '{gsub(/-|\./, "_"); print}')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "API_KEY_NAME=$(echo ${{ format('MP_API_KEY_{0}_{1}', matrix.os, matrix.python-version) }} | awk '{gsub(/-|\./, "_"); print}' | tr '[:lower:]' '[:upper:]')" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Test with pytest
         env:

--- a/mp_api/client/core/client.py
+++ b/mp_api/client/core/client.py
@@ -178,9 +178,9 @@ class BaseRester(Generic[T]):
             mp_api_info = "mp-api/" + __version__ if __version__ else None
             python_info = f"Python/{sys.version.split()[0]}"
             platform_info = f"{platform.system()}/{platform.release()}"
-            session.headers["user-agent"] = (
-                f"{mp_api_info} ({python_info} {platform_info})"
-            )
+            session.headers[
+                "user-agent"
+            ] = f"{mp_api_info} ({python_info} {platform_info})"
 
         settings = MAPIClientSettings()  # type: ignore
         max_retry_num = settings.MAX_RETRIES

--- a/mp_api/client/core/client.py
+++ b/mp_api/client/core/client.py
@@ -48,10 +48,8 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = os.getenv("SETUPTOOLS_SCM_PRETEND_VERSION")
 
 # TODO: think about how to migrate from PMG_MAPI_KEY
-DEFAULT_API_KEY = os.environ.get("MP_API_KEY", None)
-DEFAULT_ENDPOINT = os.environ.get(
-    "MP_API_ENDPOINT", "https://api.materialsproject.org/"
-)
+DEFAULT_API_KEY = os.getenv("MP_API_KEY")
+DEFAULT_ENDPOINT = os.getenv("MP_API_ENDPOINT", "https://api.materialsproject.org/")
 
 settings = MAPIClientSettings()  # type: ignore
 

--- a/mp_api/client/core/client.py
+++ b/mp_api/client/core/client.py
@@ -111,10 +111,9 @@ class BaseRester(Generic[T]):
         """
         # TODO: think about how to migrate from PMG_MAPI_KEY
         self.api_key = api_key or os.getenv("MP_API_KEY")
-        self.base_endpoint = endpoint or os.getenv(
+        self.base_endpoint = self.endpoint = endpoint or os.getenv(
             "MP_API_ENDPOINT", "https://api.materialsproject.org/"
         )
-        self.endpoint = self.endpoint
         self.debug = debug
         self.include_user_agent = include_user_agent
         self.monty_decode = monty_decode
@@ -179,9 +178,9 @@ class BaseRester(Generic[T]):
             mp_api_info = "mp-api/" + __version__ if __version__ else None
             python_info = f"Python/{sys.version.split()[0]}"
             platform_info = f"{platform.system()}/{platform.release()}"
-            session.headers[
-                "user-agent"
-            ] = f"{mp_api_info} ({python_info} {platform_info})"
+            session.headers["user-agent"] = (
+                f"{mp_api_info} ({python_info} {platform_info})"
+            )
 
         settings = MAPIClientSettings()  # type: ignore
         max_retry_num = settings.MAX_RETRIES

--- a/mp_api/client/core/client.py
+++ b/mp_api/client/core/client.py
@@ -18,7 +18,7 @@ from functools import cache
 from importlib.metadata import PackageNotFoundError, version
 from json import JSONDecodeError
 from math import ceil
-from typing import Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 from urllib.parse import quote, urljoin
 
 import requests
@@ -42,16 +42,16 @@ try:
 except ImportError:
     boto3 = None
 
+if TYPE_CHECKING:
+    from typing import Any, Callable
+
 try:
     __version__ = version("mp_api")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = os.getenv("SETUPTOOLS_SCM_PRETEND_VERSION")
 
-# TODO: think about how to migrate from PMG_MAPI_KEY
-DEFAULT_API_KEY = os.getenv("MP_API_KEY")
-DEFAULT_ENDPOINT = os.getenv("MP_API_ENDPOINT", "https://api.materialsproject.org/")
 
-settings = MAPIClientSettings()  # type: ignore
+SETTINGS = MAPIClientSettings()  # type: ignore
 
 T = TypeVar("T")
 
@@ -67,7 +67,7 @@ class BaseRester(Generic[T]):
     def __init__(
         self,
         api_key: str | None = None,
-        endpoint: str = DEFAULT_ENDPOINT,
+        endpoint: str | None = None,
         include_user_agent: bool = True,
         session: requests.Session | None = None,
         s3_client: Any | None = None,
@@ -76,7 +76,7 @@ class BaseRester(Generic[T]):
         use_document_model: bool = True,
         timeout: int = 20,
         headers: dict | None = None,
-        mute_progress_bars: bool = settings.MUTE_PROGRESS_BARS,
+        mute_progress_bars: bool = SETTINGS.MUTE_PROGRESS_BARS,
     ):
         """Initialize the REST API helper class.
 
@@ -109,9 +109,12 @@ class BaseRester(Generic[T]):
             headers: Custom headers for localhost connections.
             mute_progress_bars: Whether to disable progress bars.
         """
-        self.api_key = api_key or DEFAULT_API_KEY
-        self.base_endpoint = endpoint
-        self.endpoint = endpoint
+        # TODO: think about how to migrate from PMG_MAPI_KEY
+        self.api_key = api_key or os.getenv("MP_API_KEY")
+        self.base_endpoint = endpoint or os.getenv(
+            "MP_API_ENDPOINT", "https://api.materialsproject.org/"
+        )
+        self.endpoint = self.endpoint
         self.debug = debug
         self.include_user_agent = include_user_agent
         self.monty_decode = monty_decode

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -136,10 +136,10 @@ class MPRester:
                 If so, it will use that environment variable. This makes
                 easier for heavy users to simply add this environment variable to
                 their setups and MPRester can then be called without any arguments.
-            endpoint (str): Url of endpoint to access the MaterialsProject REST
+            endpoint (str): URL of endpoint to access the MaterialsProject REST
                 interface. Defaults to the standard Materials Project REST
                 address at "https://api.materialsproject.org", but
-                can be changed to other urls implementing a similar interface.
+                can be changed to other URLs implementing a similar interface.
             notify_db_version (bool): If True, the current MP database version will
                 be retrieved and logged locally in the ~/.mprester.log.yaml. If the database
                 version changes, you will be notified. The current database version is

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -162,9 +162,7 @@ class MPRester:
 
         """
         # SETTINGS tries to read API key from ~/.config/.pmgrc.yaml
-        api_key = (
-            api_key or os.environ.get("MP_API_KEY") or SETTINGS.get("PMG_MAPI_KEY")
-        )
+        api_key = api_key or os.getenv("MP_API_KEY") or SETTINGS.get("PMG_MAPI_KEY")
 
         if api_key and len(api_key) != 32:
             raise ValueError(
@@ -174,7 +172,7 @@ class MPRester:
             )
 
         self.api_key = api_key
-        self.endpoint = endpoint or os.environ.get(
+        self.endpoint = endpoint or os.getenv(
             "MP_API_ENDPOINT", "https://api.materialsproject.org/"
         )
         self.headers = headers or {}

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -254,7 +254,7 @@ class MPRester:
         core_resters = {
             cls.suffix.split("/")[0]: cls(
                 api_key=api_key,
-                endpoint=endpoint,
+                endpoint=self.endpoint,
                 include_user_agent=include_user_agent,
                 session=self.session,
                 monty_decode=monty_decode,
@@ -277,7 +277,7 @@ class MPRester:
                 if len(suffix_split) == 1:
                     rester = cls(
                         api_key=api_key,
-                        endpoint=endpoint,
+                        endpoint=self.endpoint,
                         include_user_agent=include_user_agent,
                         session=self.session,
                         monty_decode=monty_decode
@@ -307,7 +307,7 @@ class MPRester:
                 cls = _rester_map[_attr]
                 rester = cls(
                     api_key=api_key,
-                    endpoint=endpoint,
+                    endpoint=self.endpoint,
                     include_user_agent=include_user_agent,
                     session=self.session,
                     monty_decode=monty_decode

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -6,7 +6,7 @@ import os
 import warnings
 from functools import cache, lru_cache
 from json import loads
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from emmet.core.electronic_structure import BSPathType
 from emmet.core.mpid import MPID
@@ -60,6 +60,9 @@ from mp_api.client.routes.materials import (
 from mp_api.client.routes.materials.materials import MaterialsRester
 from mp_api.client.routes.molecules import MoleculeRester
 
+if TYPE_CHECKING:
+    from typing import Literal
+
 _DEPRECATION_WARNING = (
     "MPRester is being modernized. Please use the new method suggested and "
     "read more about these changes at https://docs.materialsproject.org/api. The current "
@@ -68,11 +71,6 @@ _DEPRECATION_WARNING = (
 
 _EMMET_SETTINGS = EmmetSettings()  # type: ignore
 _MAPI_SETTINGS = MAPIClientSettings()  # typeL ignore # type: ignore
-
-DEFAULT_API_KEY = os.environ.get("MP_API_KEY", None)
-DEFAULT_ENDPOINT = os.environ.get(
-    "MP_API_ENDPOINT", "https://api.materialsproject.org/"
-)
 
 
 class MPRester:
@@ -124,7 +122,7 @@ class MPRester:
     def __init__(
         self,
         api_key: str | None = None,
-        endpoint: str = DEFAULT_ENDPOINT,
+        endpoint: str | None = None,
         notify_db_version: bool = False,
         include_user_agent: bool = True,
         monty_decode: bool = True,
@@ -169,7 +167,9 @@ class MPRester:
 
         """
         # SETTINGS tries to read API key from ~/.config/.pmgrc.yaml
-        api_key = api_key or DEFAULT_API_KEY or SETTINGS.get("PMG_MAPI_KEY")
+        api_key = (
+            api_key or os.environ.get("MP_API_KEY") or SETTINGS.get("PMG_MAPI_KEY")
+        )
 
         if api_key and len(api_key) != 32:
             raise ValueError(
@@ -179,7 +179,9 @@ class MPRester:
             )
 
         self.api_key = api_key
-        self.endpoint = endpoint
+        self.endpoint = endpoint or os.environ.get(
+            "MP_API_ENDPOINT", "https://api.materialsproject.org/"
+        )
         self.headers = headers or {}
         self.session = session or BaseRester._create_session(
             api_key=self.api_key,

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -63,11 +63,6 @@ from mp_api.client.routes.molecules import MoleculeRester
 if TYPE_CHECKING:
     from typing import Literal
 
-_DEPRECATION_WARNING = (
-    "MPRester is being modernized. Please use the new method suggested and "
-    "read more about these changes at https://docs.materialsproject.org/api. The current "
-    "methods will be retained until at least January 2022 for backwards compatibility."
-)
 
 _EMMET_SETTINGS = EmmetSettings()  # type: ignore
 _MAPI_SETTINGS = MAPIClientSettings()  # typeL ignore # type: ignore

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -64,8 +64,8 @@ if TYPE_CHECKING:
     from typing import Literal
 
 
-_EMMET_SETTINGS = EmmetSettings()  # type: ignore
-_MAPI_SETTINGS = MAPIClientSettings()  # typeL ignore # type: ignore
+_EMMET_SETTINGS = EmmetSettings()
+_MAPI_SETTINGS = MAPIClientSettings()
 
 
 class MPRester:

--- a/tests/materials/test_materials.py
+++ b/tests/materials/test_materials.py
@@ -51,9 +51,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 

--- a/tests/materials/test_summary.py
+++ b/tests/materials/test_summary.py
@@ -59,9 +59,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client():
     search_method = SummaryRester().search
 

--- a/tests/materials/test_tasks.py
+++ b/tests/materials/test_tasks.py
@@ -39,9 +39,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 

--- a/tests/materials/test_thermo.py
+++ b/tests/materials/test_thermo.py
@@ -48,9 +48,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 

--- a/tests/materials/test_xas.py
+++ b/tests/materials/test_xas.py
@@ -44,9 +44,7 @@ custom_field_tests = {
 
 
 @pytest.mark.skip(reason="Temp skip until timeout update.")
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 

--- a/tests/molecules/test_jcesr.py
+++ b/tests/molecules/test_jcesr.py
@@ -35,9 +35,7 @@ custom_field_tests = {
 }  # type: dict
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client(rester):
     search_method = rester.search
 

--- a/tests/molecules/test_summary.py
+++ b/tests/molecules/test_summary.py
@@ -34,9 +34,7 @@ custom_field_tests = {
 
 
 @pytest.mark.skip(reason="Temporary until data adjustments")
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 def test_client():
     search_method = MoleculesSummaryRester().search
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,9 +49,7 @@ resters_to_test = [
 ]
 
 
-@pytest.mark.skipif(
-    os.environ.get("MP_API_KEY", None) is None, reason="No API key found."
-)
+@pytest.mark.skipif(os.getenv("MP_API_KEY") is None, reason="No API key found.")
 @pytest.mark.parametrize("rester", resters_to_test)
 def test_generic_get_methods(rester):
     # -- Test generic search and get_data_by_id methods

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,6 @@
 import os
+import warnings
+
 import pytest
 
 from mp_api.client import MPRester
@@ -41,7 +43,6 @@ ignore_generic = [
 
 
 mpr = MPRester()
-print(os.getenv("MP_API_KEY"), mpr.api_key, mpr.session.headers)
 
 # Temporarily ignore molecules resters while molecules query operators are changed
 resters_to_test = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,4 @@
 import os
-import warnings
-
 import pytest
 
 from mp_api.client import MPRester
@@ -43,6 +41,7 @@ ignore_generic = [
 
 
 mpr = MPRester()
+print(os.getenv("MP_API_KEY"), mpr.api_key, mpr.session.headers)
 
 # Temporarily ignore molecules resters while molecules query operators are changed
 resters_to_test = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -83,7 +83,3 @@ def test_generic_get_methods(rester):
                 key_only_resters[name], fields=[rester.primary_key]
             )
             assert isinstance(doc, rester.document_model)
-
-
-if os.getenv("MP_API_KEY", None) is None:
-    pytest.mark.skip(test_generic_get_methods)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pytest
 
@@ -66,6 +67,9 @@ def test_generic_get_methods(rester):
     )
 
     if name not in ignore_generic:
+        warnings.filterwarnings(
+            "ignore", "get_data_by_id is deprecated", DeprecationWarning
+        )
         if name not in key_only_resters:
             doc = rester._query_resource_data(
                 {"_limit": 1}, fields=[rester.primary_key]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -60,16 +60,12 @@ def test_generic_get_methods(rester):
         endpoint=mpr.endpoint,
         include_user_agent=True,
         session=mpr.session,
-        monty_decode=True
-        if rester not in [TaskRester, ProvenanceRester]  # type: ignore
-        else False,  # Disable monty decode on nested data which may give errors
+        # Disable monty decode on nested data which may give errors
+        monty_decode=rester not in [TaskRester, ProvenanceRester],
         use_document_model=True,
     )
 
     if name not in ignore_generic:
-        warnings.filterwarnings(
-            "ignore", "get_data_by_id is deprecated", DeprecationWarning
-        )
         if name not in key_only_resters:
             doc = rester._query_resource_data(
                 {"_limit": 1}, fields=[rester.primary_key]

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -28,8 +28,6 @@ from pymatgen.phonon.dos import PhononDos
 from mp_api.client import MPRester
 from mp_api.client.core.settings import MAPIClientSettings
 
-FAKE_MP_API_KEY = "12345678901234567890123456789012"  # 32 chars
-
 
 @pytest.fixture()
 def mpr():
@@ -40,6 +38,9 @@ def mpr():
 
 @pytest.mark.skipif(os.getenv("MP_API_KEY", None) is None, reason="No API key found.")
 class TestMPRester:
+    fake_mp_api_key = "12345678901234567890123456789012"  # 32 chars
+    default_endpoint = "https://api.materialsproject.org/"
+
     def test_get_structure_by_material_id(self, mpr):
         s0 = mpr.get_structure_by_material_id("mp-149")
         assert s0.formula == "Si2"
@@ -341,10 +342,10 @@ class TestMPRester:
         importlib.reload(mp_api.client)
         from mp_api.client import MPRester
 
-        monkeypatch.setenv("MP_API_KEY", FAKE_MP_API_KEY)
-        monkeypatch.setenv("MP_API_ENDPOINT", "https://api.materialsproject.org/")
-        assert MPRester().api_key == FAKE_MP_API_KEY
-        assert MPRester().endpoint == "https://api.materialsproject.org/"
+        monkeypatch.setenv("MP_API_KEY", self.fake_mp_api_key)
+        monkeypatch.setenv("MP_API_ENDPOINT", self.default_endpoint)
+        assert MPRester().api_key == self.fake_mp_api_key
+        assert MPRester().endpoint == self.default_endpoint
 
     def test_get_api_key_from_settings(self, monkeypatch: pytest.MonkeyPatch):
         """Test environment variable "MP_API_KEY" is not set and
@@ -354,11 +355,11 @@ class TestMPRester:
         assert os.environ.get("MP_API_KEY") is None
 
         # patch pymatgen.core.SETTINGS to contain PMG_MAPI_KEY
-        monkeypatch.setitem(SETTINGS, "PMG_MAPI_KEY", FAKE_MP_API_KEY)
+        monkeypatch.setitem(SETTINGS, "PMG_MAPI_KEY", self.fake_mp_api_key)
 
-        assert MPRester().api_key == FAKE_MP_API_KEY
+        assert MPRester().api_key == self.fake_mp_api_key
 
     def test_get_default_endpoint(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("MP_API_ENDPOINT", raising=False)
         assert os.environ.get("MP_API_ENDPOINT") is None
-        assert MPRester().endpoint == "https://api.materialsproject.org/"
+        assert MPRester().endpoint == self.default_endpoint

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -343,6 +343,7 @@ class TestMPRester:
         monkeypatch.setenv("MP_API_KEY", "INVALID KEY")
 
         importlib.reload(mp_api.client)
+        from mp_api.client import MPRester
 
         monkeypatch.setenv("MP_API_KEY", FAKE_MP_API_KEY)
         monkeypatch.setenv("MP_API_ENDPOINT", "https://api.materialsproject.org/")
@@ -354,9 +355,14 @@ class TestMPRester:
         get "PMG_MAPI_KEY" from "SETTINGS".
         """
         monkeypatch.delenv("MP_API_KEY", raising=False)
+        assert os.environ.get("MP_API_KEY") is None
 
         # patch pymatgen.core.SETTINGS to contain PMG_MAPI_KEY
         monkeypatch.setitem(SETTINGS, "PMG_MAPI_KEY", FAKE_MP_API_KEY)
 
-        # create MPRester and check that it picked up the API key from SETTINGS
         assert MPRester().api_key == FAKE_MP_API_KEY
+
+    def test_get_default_endpoint(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("MP_API_ENDPOINT", raising=False)
+        assert os.environ.get("MP_API_ENDPOINT") is None
+        assert MPRester().endpoint == "https://api.materialsproject.org/"

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -348,7 +348,7 @@ class TestMPRester:
         assert MPRester().api_key == self.fake_mp_api_key
         assert MPRester().endpoint == self.default_endpoint
 
-    def test_get_api_key_from_settings(self, monkeypatch: pytest.MonkeyPatch):
+    def test_get_api_key_endpoint_from_settings(self, monkeypatch: pytest.MonkeyPatch):
         """Test environment variable "MP_API_KEY" is not set and
         get "PMG_MAPI_KEY" from "SETTINGS".
         """
@@ -359,7 +359,7 @@ class TestMPRester:
 
         assert MPRester().api_key == self.fake_mp_api_key
 
-    def test_get_default_endpoint_api_key(self, monkeypatch: pytest.MonkeyPatch):
+    def test_get_default_api_key_endpoint(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv("MP_API_ENDPOINT", raising=False)
         assert MPRester().endpoint == self.default_endpoint
 

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -332,19 +332,22 @@ class TestMPRester:
         docs = mpr.summary.search(material_ids=mpids, fields=["material_ids"])
         assert len(docs) == 10000
 
-    def test_get_api_key_from_env_var(self, monkeypatch: pytest.MonkeyPatch):
-        """Ensure the MP_API_KEY from environment variable is retrieved
-        at runtime, not import time.
+    def test_get_api_key_endpoint_from_env_var(self, monkeypatch: pytest.MonkeyPatch):
+        """Ensure the MP_API_KEY and MP_API_ENDPOINT from environment variable
+        is retrieved at runtime, not import time.
         """
-        # Mock an invalid key set before import MPRester
+        # Mock an invalid key and endpoint set before import MPRester
         import mp_api.client
 
+        monkeypatch.setenv("MP_API_ENDPOINT", "INVALID ENDPOINT")
         monkeypatch.setenv("MP_API_KEY", "INVALID KEY")
 
         importlib.reload(mp_api.client)
 
         monkeypatch.setenv("MP_API_KEY", FAKE_MP_API_KEY)
+        monkeypatch.setenv("MP_API_ENDPOINT", "https://api.materialsproject.org/")
         assert MPRester().api_key == FAKE_MP_API_KEY
+        assert MPRester().endpoint == "https://api.materialsproject.org/"
 
     def test_get_api_key_from_settings(self, monkeypatch: pytest.MonkeyPatch):
         """Test environment variable "MP_API_KEY" is not set and

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -33,16 +33,12 @@ FAKE_MP_API_KEY = "12345678901234567890123456789012"  # 32 chars
 
 @pytest.fixture()
 def mpr():
-    # Only mock the API key in GitHub CI environment,
-    # otherwise people cannot run tests locally as the key is invalid
-    if os.getenv("GITHUB_ACTIONS") is not None:
-        os.environ["MP_API_KEY"] = FAKE_MP_API_KEY
-
     rester = MPRester()
     yield rester
     rester.session.close()
 
 
+@pytest.mark.skipif(os.getenv("MP_API_KEY", None) is None, reason="No API key found.")
 class TestMPRester:
     def test_get_structure_by_material_id(self, mpr):
         s0 = mpr.get_structure_by_material_id("mp-149")

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -43,7 +43,6 @@ def mpr():
     rester.session.close()
 
 
-@pytest.mark.skipif(os.getenv("MP_API_KEY", None) is None, reason="No API key found.")
 class TestMPRester:
     def test_get_structure_by_material_id(self, mpr):
         s0 = mpr.get_structure_by_material_id("mp-149")
@@ -337,7 +336,7 @@ class TestMPRester:
         """Ensure the MP_API_KEY from environment variable is retrieved
         at runtime, not import time.
         """
-        # Mock a invalid key set before import MPRester
+        # Mock an invalid key set before import MPRester
         import mp_api.client
 
         monkeypatch.setenv("MP_API_KEY", "INVALID KEY")


### PR DESCRIPTION
### Summary

- Lazily get `endpoint` and `api_key`, to close #935
- [x] Add more unit tests