### PR TITLE
Add cohesive energy support

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -1550,7 +1550,12 @@ class MPRester:
 
     @lru_cache
     def get_atom_reference_data(
-        self, funcs: tuple[str] = ("PBE", "SCAN", "r2SCAN",)
+        self,
+        funcs: tuple[str] = (
+            "PBE",
+            "SCAN",
+            "r2SCAN",
+        ),
     ) -> dict[str, dict[str, float]]:
         """Retrieve energies of isolated neutral atoms from MPContribs.
 

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -1478,7 +1478,7 @@ class MPRester:
             """
         )
 
-    def get_cohesive_energy_per_atom_by_material_id(
+    def get_e_coh_per_atom_by_material_id(
         self, material_id: MPID | str | list[MPID | str]
     ) -> float | dict[str, float]:
         """Obtain the cohesive energy, in eV/atom, of the structures corresponding to one or many MPIDs.
@@ -1550,7 +1550,7 @@ class MPRester:
 
     @lru_cache
     def get_atom_reference_data(
-        self, funcs: list[str] = None
+        self, funcs: tuple[str] = ("PBE", "SCAN", "r2SCAN",)
     ) -> dict[str, dict[str, float]]:
         """Retrieve energies of isolated neutral atoms from MPContribs.
 
@@ -1565,8 +1565,6 @@ class MPRester:
         """
         conv_fac = {"eV": 1.0, "meV": 1e-3, "µeV": 1e-6}
 
-        default_funcs = {"PBE", "SCAN", "r2SCAN"}
-        funcs = funcs or default_funcs
         _atomic_energies = self.contribs.query_contributions(
             query={"project": "isolated_atom_energies"},
             fields=["formula", *[f"data.{dfa}.energy" for dfa in funcs]],

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -1486,17 +1486,16 @@ class MPRester:
         """Obtain the cohesive energy of the structure(s) corresponding to multiple MPIDs.
 
         Args:
-            material_id ([MPID | str]) : List of MPIDs to compute cohesive energies.
+            material_ids ([MPID | str]) : List of MPIDs to compute cohesive energies.
             normalization (str = "atom" (default) or "formula_unit") :
                 Whether to normalize the cohesive energy by the number of atoms (default)
                 or by the number of formula units.
                 Note that the current default is inconsistent with the legacy API.
 
         Returns:
-            (dict[str,float]) : The cohesive energies (in eV/atom or eV/formula unit) for 
+            (dict[str,float]) : The cohesive energies (in eV/atom or eV/formula unit) for
             each material, indexed by MPID.
         """
-
         entry_preference = {
             k: i for i, k in enumerate(["GGA", "GGA_U", "SCAN", "R2SCAN"])
         }
@@ -1577,15 +1576,14 @@ class MPRester:
             (dict[str, dict[str, float]]) : dict containing isolated atom energies,
             indexed first by the functionals in funcs, and second by the atom.
         """
-
         _atomic_energies = self.contribs.query_contributions(
             query={"project": "isolated_atom_energies"},
             fields=["formula", *[f"data.{dfa}.energy" for dfa in funcs]],
         ).get("data")
 
         return {
-            dfa : {
-                entry["formula"] : entry["data"][dfa]["energy"]["value"]
+            dfa: {
+                entry["formula"]: entry["data"][dfa]["energy"]["value"]
                 for entry in _atomic_energies
             }
             for dfa in funcs

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -1479,15 +1479,16 @@ class MPRester:
         )
 
     def get_cohesive_energy(
-        self, material_id: MPID | str | list[MPID | str],
-        normalization : Literal["atom","formula_unit"] = "atom"
+        self,
+        material_id: MPID | str | list[MPID | str],
+        normalization: Literal["atom", "formula_unit"] = "atom",
     ) -> float | dict[str, float]:
         """Obtain the cohesive energy of the structure(s) corresponding to one or many MPIDs.
 
         Args:
             material_id (MPID or str or [MPID | str]) : a single MPID or a list of many to compute
                 cohesive energies for.
-            normalization (str = "atom" (default) or "formula_unit")
+            normalization (str = "atom" (default) or "formula_unit") :
                 Whether to normalize the cohesive energy by the number of atoms (default)
                 or by the number of formula units.
                 Note that the current default is inconsistent with the legacy API.
@@ -1547,7 +1548,7 @@ class MPRester:
                 entries[prefered_func]["composition"],
                 entries[prefered_func]["total_energy_per_atom"],
                 atomic_energies[run_type_to_dfa.get(prefered_func, prefered_func)],
-                normalization = normalization,
+                normalization=normalization,
             )
 
         if len(material_id) == 1:
@@ -1594,7 +1595,7 @@ class MPRester:
         composition: Composition | dict,
         energy_per_atom: float,
         atomic_energies: dict[str, float],
-        normalization : Literal["atom","formula_unit"] = "atom"
+        normalization: Literal["atom", "formula_unit"] = "atom",
     ) -> float:
         """Obtain the cohesive energy of a given composition and energy.
 
@@ -1603,7 +1604,7 @@ class MPRester:
             energy_per_atom (float) : the energy per atom of the structure.
             atomic_energies (dict[str,float]) : a dict containing reference total energies
                 of neutral atoms.
-            normalization (str = "atom" (default) or "formula_unit")
+            normalization (str = "atom" (default) or "formula_unit") :
                 Whether to normalize the cohesive energy by the number of atoms (default)
                 or by the number of formula units.
 
@@ -1620,4 +1621,4 @@ class MPRester:
             return energy_per_atom - atomic_energy / natom
         elif normalization == "formula_unit":
             num_form_unit = comp.get_reduced_composition_and_factor()[1]
-            return (energy_per_atom*natom - atomic_energy) / num_form_unit
+            return (energy_per_atom * natom - atomic_energy) / num_form_unit

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -62,6 +62,7 @@ from mp_api.client.routes.molecules import MoleculeRester
 
 if TYPE_CHECKING:
     from typing import Literal
+
     from pymatgen.core import Composition
 
 
@@ -1479,27 +1480,36 @@ class MPRester:
             """
         )
 
-    def get_cohesive_energy_by_material_id(self, material_id : MPID | str | list[MPID | str]) -> float:
-        
+    def get_cohesive_energy_by_material_id(
+        self, material_id: MPID | str | list[MPID | str]
+    ) -> float:
         if isinstance(material_id, MPID | str):
             material_id = [material_id]
 
         mat_info = self.materials.search(
-            material_ids=material_id,
-            fields=["origins","composition","material_id"]
+            material_ids=material_id, fields=["origins", "composition", "material_id"]
         )
 
         mpid_to_task_id = {}
         for mat_doc in mat_info:
             for prop in mat_doc.origins:
-                if prop.name.lower() in {"energy","structure",}:
+                if prop.name.lower() in {
+                    "energy",
+                    "structure",
+                }:
                     mpid_to_task_id[mat_doc.material_id] = prop.task_id
                     break
-        task_id_to_mpid = {v : k for k, v in mpid_to_task_id.items()}
+        task_id_to_mpid = {v: k for k, v in mpid_to_task_id.items()}
 
         tasks = self.tasks.search(
-            task_ids = list(task_id_to_mpid),
-            fields=["run_type","output.structure","output.energy","calcs_reversed","task_id"]
+            task_ids=list(task_id_to_mpid),
+            fields=[
+                "run_type",
+                "output.structure",
+                "output.energy",
+                "calcs_reversed",
+                "task_id",
+            ],
         )
 
         atomic_energies = self.get_atom_reference_data()
@@ -1507,44 +1517,56 @@ class MPRester:
         e_coh_per_atom = {}
         for task in tasks:
             run_type = str(task.run_type or TaskDoc._get_run_type(task.calcs_reversed))
-            if run_type in {"GGA","GGA+U"}:
+            if run_type in {"GGA", "GGA+U"}:
                 dfa = "PBE"
-            elif run_type in {"r2SCAN","r2SCAN+U"}:
+            elif run_type in {"r2SCAN", "r2SCAN+U"}:
                 dfa = "r2SCAN"
             else:
-                warnings.warn(f"No reference atomic energies for run type {run_type} available (task {task.task_id}, material {task_id_to_mpid[task.task_id]})!")
+                warnings.warn(
+                    f"No reference atomic energies for run type {run_type} available (task {task.task_id}, material {task_id_to_mpid[task.task_id]})!"
+                )
                 continue
 
             structure = task.output.structure or task.calcs_reversed[0].output.structure
             energy = task.output.energy or task.calcs_reversed[0].output.energy
 
             if structure is not None and energy is not None:
-                e_coh_per_atom[task_id_to_mpid[task.task_id]] = self._get_cohesive_energy_per_atom(
+                e_coh_per_atom[
+                    task_id_to_mpid[task.task_id]
+                ] = self._get_cohesive_energy_per_atom(
                     structure.composition, energy, atomic_energies[dfa]
                 )
 
         return e_coh_per_atom
-    
+
     @lru_cache
-    def get_atom_reference_data(self, funcs : list[str] = ["PBE","r2SCAN"]) -> dict[str,dict[str, float]]:
+    def get_atom_reference_data(
+        self, funcs: list[str] = None
+    ) -> dict[str, dict[str, float]]:
+        if funcs is None:
+            funcs = ["PBE", "r2SCAN"]
         _atomic_energies = self.contribs.query_contributions(
-            query = {"project": "isolated_atom_energies"},
-            fields = ["formula", *[f"data.{dfa}.energy" for dfa in funcs]]
+            query={"project": "isolated_atom_energies"},
+            fields=["formula", *[f"data.{dfa}.energy" for dfa in funcs]],
         ).get("data")
 
-        atomic_energies = {dfa : {} for dfa in {"PBE", "r2SCAN"}}
+        atomic_energies = {dfa: {} for dfa in {"PBE", "r2SCAN"}}
         for entry in _atomic_energies:
             for dfa in atomic_energies:
-                conv_fac = 1.
+                conv_fac = 1.0
                 if entry["data"][dfa]["energy"]["unit"] == "meV":
                     conv_fac = 1e-3
-                atomic_energies[dfa][entry["formula"]] = entry["data"][dfa]["energy"]["value"] * conv_fac
+                atomic_energies[dfa][entry["formula"]] = (
+                    entry["data"][dfa]["energy"]["value"] * conv_fac
+                )
         return atomic_energies
-    
+
     @staticmethod
-    def _get_cohesive_energy_per_atom(composition: Composition, energy: float, atomic_energies : dict[str,float]) -> float:
+    def _get_cohesive_energy_per_atom(
+        composition: Composition, energy: float, atomic_energies: dict[str, float]
+    ) -> float:
         comp = composition.remove_charges()
         atomic_energy = sum(
-            coeff*atomic_energies[str(element)] for element, coeff in comp.items()
+            coeff * atomic_energies[str(element)] for element, coeff in comp.items()
         )
-        return (energy - atomic_energy)/sum(comp.values())
+        return (energy - atomic_energy) / sum(comp.values())

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -423,7 +423,6 @@ class TestMPRester:
                 use_document_model=monty_decode, monty_decode=monty_decode
             ) as _mpr:
                 for norm, refs in ref_e_coh.items():
-
                     _e_coh = _mpr.get_cohesive_energy(list(refs), normalization=norm)
                     if norm == "atom":
                         e_coh["serial" if monty_decode else "noserial"] = _e_coh.copy()

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -414,20 +414,22 @@ class TestMPRester:
                 "mp-123": -4.029208982500002,
                 "mp-149": -4.669184594999999,
                 "mp-4163": -76.21683144500001,
-                "mp-19017": -34.533869725
-            }
-        } 
+                "mp-19017": -34.533869725,
+            },
+        }
         e_coh = {}
         for monty_decode in (True, False):
             with MPRester(
                 use_document_model=monty_decode, monty_decode=monty_decode
             ) as _mpr:
                 for norm, refs in ref_e_coh.items():
-                    single_e_coh = _mpr.get_cohesive_energy("mp-123",normalization=norm)
+                    single_e_coh = _mpr.get_cohesive_energy(
+                        "mp-123", normalization=norm
+                    )
                     assert isinstance(single_e_coh, float)
                     assert single_e_coh == pytest.approx(refs["mp-123"])
 
-                    _e_coh = _mpr.get_cohesive_energy(list(refs),normalization=norm)
+                    _e_coh = _mpr.get_cohesive_energy(list(refs), normalization=norm)
                     if norm == "atom":
                         e_coh["serial" if monty_decode else "noserial"] = _e_coh.copy()
 

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -423,11 +423,6 @@ class TestMPRester:
                 use_document_model=monty_decode, monty_decode=monty_decode
             ) as _mpr:
                 for norm, refs in ref_e_coh.items():
-                    single_e_coh = _mpr.get_cohesive_energy(
-                        "mp-123", normalization=norm
-                    )
-                    assert isinstance(single_e_coh, float)
-                    assert single_e_coh == pytest.approx(refs["mp-123"])
 
                     _e_coh = _mpr.get_cohesive_energy(list(refs), normalization=norm)
                     if norm == "atom":

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -373,53 +373,57 @@ class TestMPRester:
             MPRester().get_structure_by_material_id("mp-149")
 
     def test_get_cohesive_energy_per_atom_utility(self):
-
-        composition = {"H": 5, "V": 2,"P": 3,}
-        toten_per_atom = -2.e3
+        composition = {
+            "H": 5,
+            "V": 2,
+            "P": 3,
+        }
+        toten_per_atom = -2.0e3
         atomic_energies = {"H": -13.6, "V": -7.2, "P": -0.1}
 
         by_hand_e_coh = toten_per_atom - sum(
             atomic_energies[k] * v for k, v in composition.items()
-        )/ sum(composition.values())
+        ) / sum(composition.values())
 
-        assert MPRester._get_cohesive_energy_per_atom(composition,toten_per_atom,atomic_energies) == pytest.approx(by_hand_e_coh)
+        assert MPRester._get_cohesive_energy_per_atom(
+            composition, toten_per_atom, atomic_energies
+        ) == pytest.approx(by_hand_e_coh)
 
-    def test_get_atom_references(self,mpr):
+    def test_get_atom_references(self, mpr):
         ae = mpr.get_atom_reference_data(funcs=("PBE",))
         assert list(ae) == ["PBE"]
         assert len(ae["PBE"]) == 89
-        assert all(isinstance(v,float) for v in ae["PBE"].values())
+        assert all(isinstance(v, float) for v in ae["PBE"].values())
 
         ae = mpr.get_atom_reference_data()
-        assert set(ae) == {"PBE","r2SCAN","SCAN"}
+        assert set(ae) == {"PBE", "r2SCAN", "SCAN"}
+        assert all(len(entries) == 89 for entries in ae.values())
         assert all(
-            len(entries) == 89 for entries in ae.values()
+            isinstance(v, float) for entries in ae.values() for v in entries.values()
         )
-        assert all(isinstance(v,float) for entries in ae.values() for v in entries.values())
 
     def test_get_cohesive_energy(self):
-        
         ref_e_coh = {
             "mp-123": -4.029208982500002,
             "mp-149": -4.669184594999999,
             "mp-4163": -6.351402620416668,
-            "mp-19017": -4.933409960714286
+            "mp-19017": -4.933409960714286,
         }
-        mpids = ["mp-123","mp-149","mp-4163","mp-19017"]
+        mpids = ["mp-123", "mp-149", "mp-4163", "mp-19017"]
         e_coh = {}
         for monty_decode in (True, False):
-            with MPRester(use_document_model=monty_decode,monty_decode=monty_decode) as _mpr:
+            with MPRester(
+                use_document_model=monty_decode, monty_decode=monty_decode
+            ) as _mpr:
                 single_e_coh = _mpr.get_e_coh_per_atom_by_material_id("mp-123")
-                assert isinstance(single_e_coh,float)
+                assert isinstance(single_e_coh, float)
                 assert single_e_coh == pytest.approx(ref_e_coh["mp-123"])
 
                 _e_coh = _mpr.get_e_coh_per_atom_by_material_id(mpids)
                 e_coh["serial" if monty_decode else "noserial"] = _e_coh.copy()
 
                 # Ensure energies match reference data
-                assert all(
-                    v == pytest.approx(ref_e_coh[k]) for k, v in _e_coh.items()
-                )
+                assert all(v == pytest.approx(ref_e_coh[k]) for k, v in _e_coh.items())
 
         # Ensure energies are the same regardless of serialization
         assert all(


### PR DESCRIPTION
Adds in [legacy API feature](https://github.com/materialsproject/pymatgen/blob/da607e86f9ce8aec942067c6c1a4fda6e04915dd/src/pymatgen/ext/matproj_legacy.py#L1271) to compute cohesive energies on the fly from tabulated reference atomic energies. Pulls in atomic data that is hosted on [MPContribs](https://next-gen.materialsproject.org/contribs/projects/isolated_atom_energies) and cached

This feature has been requested by [users on matsci](https://matsci.org/t/get-cohesive-energy-from-materials-project/58195)

The legacy API normalized the cohesive energy by formula unit - this is less common than normalizing by atom. By atom normalization is now the default. with an option to instead normalize by formula unit.

To-do's:
~- Add SCAN atom calculations (in progress calculating)~
~- Add tests~
~- Publish contribs data~