### PR TITLE
Feature: allow for user to add entries to Pourbaix

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -783,7 +783,7 @@ class MPRester:
 
     def get_pourbaix_entries(
         self,
-        chemsys: str | list,
+        chemsys: str | list[str] | list[ComputedEntry | ComputedStructureEntry],
         solid_compat="MaterialsProject2020Compatibility",
         use_gibbs: Literal[300] | None = None,
     ):
@@ -791,9 +791,14 @@ class MPRester:
         a Pourbaix diagram from the rest interface.
 
         Args:
-            chemsys (str or [str]): Chemical system string comprising element
+            chemsys (str or [str] or Computed(Structure)Entry):
+                Chemical system string comprising element
                 symbols separated by dashes, e.g., "Li-Fe-O" or List of element
                 symbols, e.g., ["Li", "Fe", "O"].
+
+                Can also be a list of Computed(Structure)Entry objects to allow
+                for adding extra calculation data to the Pourbaix Diagram.
+                If this is set, the chemsys will be inferred from the entries.
             solid_compat: Compatibility scheme used to pre-process solid DFT energies prior
                 to applying aqueous energy adjustments. May be passed as a class (e.g.
                 MaterialsProject2020Compatibility) or an instance
@@ -815,6 +820,27 @@ class MPRester:
             MaterialsProjectCompatibility,
         )
         from pymatgen.entries.computed_entries import ComputedEntry
+
+        thermo_types = ["GGA_GGA+U"]
+        user_entries: list[ComputedEntry | ComputedStructureEntry] = []
+        if isinstance(chemsys, list) and all(
+            isinstance(v, ComputedEntry | ComputedStructureEntry) for v in chemsys
+        ):
+            user_entries = [ce.copy() for ce in chemsys]
+
+            elements = set()
+            for entry in user_entries:
+                elements.update(entry.elements)
+            chemsys = [ele.name for ele in elements]
+
+            user_run_types = set(
+                [
+                    entry.parameters.get("run_type", "unknown").lower()
+                    for entry in user_entries
+                ]
+            )
+            if any("r2scan" in rt for rt in user_run_types):
+                thermo_types = ["GGA_GGA+U_R2SCAN"]
 
         if solid_compat == "MaterialsProjectCompatibility":
             solid_compat = MaterialsProjectCompatibility()
@@ -851,9 +877,13 @@ class MPRester:
         # TODO - would be great if the commented line below would work
         # However for some reason you cannot process GibbsComputedStructureEntry with
         # MaterialsProjectAqueousCompatibility
-        ion_ref_entries = self.get_entries_in_chemsys(
-            list([str(e) for e in ion_ref_elts] + ["O", "H"]),
-            # use_gibbs=use_gibbs
+        ion_ref_entries = (
+            self.get_entries_in_chemsys(
+                list([str(e) for e in ion_ref_elts] + ["O", "H"]),
+                additional_criteria={"thermo_types": thermo_types}
+                # use_gibbs=use_gibbs
+            )
+            + user_entries
         )
 
         # suppress the warning about supplying the required energies; they will be calculated from the

--- a/mp_api/client/routes/materials/phonon.py
+++ b/mp_api/client/routes/materials/phonon.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-import numpy as np
 from collections import defaultdict
 
+import numpy as np
+from emmet.core.phonon import PhononBS, PhononBSDOSDoc, PhononDOS
 from monty.json import MontyDecoder
-from emmet.core.phonon import PhononBSDOSDoc, PhononBS, PhononDOS
 
 from mp_api.client.core import BaseRester, MPRestError
 from mp_api.client.core.utils import validate_ids


### PR DESCRIPTION
Small tweak to `MPRester.get_pourbaix_entries` to allow for the user to specify a list of `ComputedEntry` / `ComputedStructureEntry` objects for placement on the Pourbaix diagram