### PR TITLE
add test for large result set on robocrys search

### DIFF
--- a/tests/materials/test_robocrys.py
+++ b/tests/materials/test_robocrys.py
@@ -23,3 +23,18 @@ def test_client(rester):
 
         assert doc.description is not None
         assert doc.condensed_structure is not None
+
+
+# TODO: switch this to the skipif once emmet PR 1261 is deployed to production
+# @pytest.mark.skipif(os.getenv("MP_API_KEY", None) is None, reason="No API key found.")
+@pytest.mark.skip(reason="Query with large result set fails with faceted pipeline")
+def test_client_large_result_set(rester):
+    search_method = rester.search
+
+    if search_method is not None:
+        q = {"keywords": ["Orthorhombic"], "num_chunks": 1}
+
+        doc = search_method(**q)[0]
+
+        assert doc.description is not None
+        assert doc.condensed_structure is not None


### PR DESCRIPTION
## Summary

Robocrys search prior to [emmet PR 1261](https://github.com/materialsproject/emmet/pull/1261) fails when the result set of the query is large. 

This adds a test that is skipped for now. It needs to be enabled once the emmet API with that change is deployed.

## Checklist

- [x] Tests added for new features/fixes.