### PR TITLE
Remove maggma dependence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-maggma Copyright (c) 2017, The Regents of the University of
+Copyright (c) 2017, The Regents of the University of
 California, through Lawrence Berkeley National Laboratory (subject
 to receipt of any required approvals from the U.S. Dept. of Energy).
 All rights reserved.

--- a/mp_api/client/core/utils.py
+++ b/mp_api/client/core/utils.py
@@ -4,7 +4,7 @@ import re
 from functools import cache
 from typing import Optional, get_args
 
-from maggma.utils import get_flat_models_from_model
+from emmet.core.utils import get_flat_models_from_model
 from monty.json import MSONable
 from pydantic import BaseModel
 from pydantic._internal._utils import lenient_issubclass

--- a/mp_api/client/routes/materials/robocrys.py
+++ b/mp_api/client/routes/materials/robocrys.py
@@ -32,7 +32,7 @@ class RobocrysRester(BaseRester[RobocrystallogapherDoc]):
         robocrys_docs = self._query_resource(
             criteria={"keywords": keyword_string, "_limit": chunk_size},
             suburl="text_search",
-            use_document_model=True,
+            use_document_model=self.use_document_model,
             chunk_size=chunk_size,
             num_chunks=num_chunks,
         ).get("data", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 dependencies = [
   "setuptools",
   "msgpack",
-  "maggma>=0.57.1",
   "pymatgen>=2022.3.7,!=2024.2.20",
   "typing-extensions>=3.7.4.1",
   "requests>=2.23.0",

--- a/requirements/requirements-ubuntu-latest_py3.11.txt
+++ b/requirements/requirements-ubuntu-latest_py3.11.txt
@@ -4,214 +4,126 @@
 #
 #    pip-compile --output-file=requirements/requirements-ubuntu-latest_py3.11.txt pyproject.toml
 #
-aioitertools==0.12.0
-    # via maggma
 annotated-types==0.7.0
     # via pydantic
-attrs==25.3.0
-    # via
-    #   jsonlines
-    #   jsonschema
-    #   referencing
-bcrypt==4.3.0
-    # via paramiko
 bibtexparser==1.4.3
     # via pymatgen
-boto3==1.38.37
-    # via maggma
-botocore==1.38.37
-    # via
-    #   boto3
-    #   s3transfer
-certifi==2025.6.15
+certifi==2025.8.3
     # via requests
-cffi==1.17.1
-    # via
-    #   cryptography
-    #   pynacl
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
-cryptography==45.0.4
-    # via paramiko
 cycler==0.12.1
     # via matplotlib
-dnspython==2.7.0
-    # via
-    #   maggma
-    #   pymongo
-emmet-core==0.84.8
+emmet-core==0.84.9
     # via mp-api (pyproject.toml)
-fonttools==4.58.4
+fonttools==4.59.1
     # via matplotlib
 idna==3.10
     # via requests
-jmespath==1.0.1
-    # via
-    #   boto3
-    #   botocore
 joblib==1.5.1
     # via pymatgen
-jsonlines==4.0.0
-    # via maggma
-jsonschema==4.24.0
-    # via maggma
-jsonschema-specifications==2025.4.1
-    # via jsonschema
-kiwisolver==1.4.8
+kiwisolver==1.4.9
     # via matplotlib
-latexcodec==3.0.0
+latexcodec==3.0.1
     # via pybtex
-maggma==0.71.5
-    # via mp-api (pyproject.toml)
-matplotlib==3.10.3
+matplotlib==3.10.5
     # via pymatgen
-mongomock==4.3.0
-    # via maggma
 monty==2025.3.3
     # via
     #   emmet-core
-    #   maggma
     #   mp-api (pyproject.toml)
     #   pymatgen
 mpmath==1.3.0
     # via sympy
 msgpack==1.1.1
-    # via
-    #   maggma
-    #   mp-api (pyproject.toml)
-narwhals==1.43.0
+    # via mp-api (pyproject.toml)
+narwhals==2.1.1
     # via plotly
 networkx==3.5
     # via pymatgen
-numpy==2.3.0
+numpy==2.3.2
     # via
     #   contourpy
-    #   maggma
     #   matplotlib
     #   monty
     #   pandas
     #   pymatgen
     #   scipy
     #   spglib
-orjson==3.10.18
-    # via
-    #   maggma
-    #   pymatgen
+orjson==3.11.2
+    # via pymatgen
 packaging==25.0
     # via
     #   matplotlib
-    #   mongomock
     #   plotly
 palettable==3.3.3
     # via pymatgen
-pandas==2.3.0
-    # via
-    #   maggma
-    #   pymatgen
-paramiko==3.5.1
-    # via sshtunnel
-pillow==11.2.1
-    # via matplotlib
-plotly==6.1.2
+pandas==2.3.1
     # via pymatgen
-pybtex==0.24.0
+pillow==11.3.0
+    # via matplotlib
+plotly==6.3.0
+    # via pymatgen
+pybtex==0.25.1
     # via emmet-core
-pycparser==2.22
-    # via cffi
 pydantic==2.11.7
     # via
     #   emmet-core
-    #   maggma
     #   pydantic-settings
 pydantic-core==2.33.2
     # via pydantic
-pydantic-settings==2.9.1
-    # via
-    #   emmet-core
-    #   maggma
-pydash==8.0.5
-    # via maggma
+pydantic-settings==2.10.1
+    # via emmet-core
 pymatgen==2025.6.14
     # via
     #   emmet-core
     #   mp-api (pyproject.toml)
-pymongo==4.10.1
-    # via maggma
-pynacl==1.5.0
-    # via paramiko
 pyparsing==3.2.3
     # via
     #   bibtexparser
     #   matplotlib
 python-dateutil==2.9.0.post0
     # via
-    #   botocore
-    #   maggma
     #   matplotlib
     #   pandas
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via pydantic-settings
 pytz==2025.2
-    # via
-    #   mongomock
-    #   pandas
+    # via pandas
 pyyaml==6.0.2
     # via pybtex
-pyzmq==27.0.0
-    # via maggma
-referencing==0.36.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.4
     # via
     #   mp-api (pyproject.toml)
     #   pymatgen
-rpds-py==0.25.1
-    # via
-    #   jsonschema
-    #   referencing
 ruamel-yaml==0.18.14
     # via
-    #   maggma
     #   monty
     #   pymatgen
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-s3transfer==0.13.0
-    # via boto3
-scipy==1.15.3
+scipy==1.16.1
     # via pymatgen
-sentinels==1.0.0
-    # via mongomock
 six==1.17.0
-    # via
-    #   pybtex
-    #   python-dateutil
-smart-open==7.1.0
+    # via python-dateutil
+smart-open==7.3.0.post1
     # via mp-api (pyproject.toml)
 spglib==2.6.0
     # via pymatgen
-sshtunnel==0.4.0
-    # via maggma
 sympy==1.14.0
     # via pymatgen
 tabulate==0.9.0
     # via pymatgen
 tqdm==4.67.1
-    # via
-    #   maggma
-    #   pymatgen
-typing-extensions==4.14.0
+    # via pymatgen
+typing-extensions==4.14.1
     # via
     #   emmet-core
     #   mp-api (pyproject.toml)
     #   pydantic
     #   pydantic-core
-    #   pydash
-    #   referencing
     #   spglib
     #   typing-inspection
 typing-inspection==0.4.1
@@ -222,11 +134,9 @@ tzdata==2025.2
     # via pandas
 uncertainties==3.2.3
     # via pymatgen
-urllib3==2.4.0
-    # via
-    #   botocore
-    #   requests
-wrapt==1.17.2
+urllib3==2.5.0
+    # via requests
+wrapt==1.17.3
     # via smart-open
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-ubuntu-latest_py3.11_extras.txt
+++ b/requirements/requirements-ubuntu-latest_py3.11_extras.txt
@@ -4,36 +4,29 @@
 #
 #    pip-compile --all-extras --output-file=requirements/requirements-ubuntu-latest_py3.11_extras.txt pyproject.toml
 #
-aioitertools==0.12.0
-    # via maggma
 alabaster==1.0.0
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
 arrow==1.3.0
     # via isoduration
-ase==3.25.0
+ase==3.26.0
     # via pymatgen-analysis-diffusion
 asttokens==3.0.0
     # via stack-data
 attrs==25.3.0
     # via
-    #   jsonlines
     #   jsonschema
     #   referencing
 babel==2.17.0
     # via sphinx
-bcrypt==4.3.0
-    # via paramiko
 bibtexparser==1.4.3
     # via pymatgen
 boltons==25.0.0
     # via mpcontribs-client
-boto3==1.38.37
-    # via
-    #   maggma
-    #   mp-api (pyproject.toml)
-botocore==1.38.37
+boto3==1.40.9
+    # via mp-api (pyproject.toml)
+botocore==1.40.9
     # via
     #   boto3
     #   s3transfer
@@ -43,48 +36,41 @@ bravado-core==6.1.1
     # via bravado
 cachetools==6.1.0
     # via mpcontribs-client
-certifi==2025.6.15
+certifi==2025.8.3
     # via requests
-cffi==1.17.1
-    # via
-    #   cryptography
-    #   pynacl
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.9.1
+coverage[toml]==7.10.3
     # via pytest-cov
-cryptography==45.0.4
-    # via paramiko
-custodian==2025.5.12
+custodian==2025.8.13
     # via mp-api (pyproject.toml)
 cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
     # via ipython
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 dnspython==2.7.0
     # via
-    #   maggma
     #   pyisemail
     #   pymongo
 docutils==0.21.2
     # via sphinx
-emmet-core[all]==0.84.8
+emmet-core[all]==0.84.9
     # via mp-api (pyproject.toml)
 executing==2.2.0
     # via stack-data
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   mdanalysis
     #   virtualenv
 filetype==1.2.0
     # via mpcontribs-client
-flake8==7.2.0
+flake8==7.3.0
     # via mp-api (pyproject.toml)
 flatten-dict==0.4.2
     # via mpcontribs-client
@@ -92,13 +78,13 @@ flexcache==0.3
     # via pint
 flexparser==0.4
     # via pint
-fonttools==4.58.4
+fonttools==4.59.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 griddataformats==1.0.2
     # via mdanalysis
-identify==2.6.12
+identify==2.6.13
     # via pre-commit
 idna==3.10
     # via
@@ -114,7 +100,7 @@ inflect==7.5.0
     # via robocrys
 iniconfig==2.1.0
     # via pytest
-ipython==9.3.0
+ipython==9.4.0
     # via mpcontribs-client
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -136,32 +122,29 @@ joblib==1.5.1
     #   scikit-learn
 json2html==1.3.0
     # via mpcontribs-client
-jsonlines==4.0.0
-    # via maggma
 jsonpointer==3.0.0
     # via jsonschema
 jsonref==1.1.0
     # via bravado-core
-jsonschema[format-nongpl]==4.24.0
+jsonschema[format-nongpl]==4.25.0
     # via
     #   bravado-core
-    #   maggma
     #   swagger-spec-validator
 jsonschema-specifications==2025.4.1
     # via jsonschema
-kiwisolver==1.4.8
+kiwisolver==1.4.9
     # via matplotlib
-latexcodec==3.0.0
+lark==1.2.2
+    # via rfc3987-syntax
+latexcodec==3.0.1
     # via pybtex
 lazy-loader==0.4
     # via scikit-image
-maggma==0.71.5
-    # via mp-api (pyproject.toml)
 markupsafe==3.0.2
     # via jinja2
 matminer==0.9.3
     # via robocrys
-matplotlib==3.10.3
+matplotlib==3.10.5
     # via
     #   ase
     #   mdanalysis
@@ -181,15 +164,12 @@ mdanalysis==2.9.0
     #   transport-analysis
 mmtf-python==1.1.3
     # via mdanalysis
-mongomock==4.3.0
-    # via maggma
 monotonic==1.6
     # via bravado
 monty==2025.3.3
     # via
     #   custodian
     #   emmet-core
-    #   maggma
     #   matminer
     #   mp-api (pyproject.toml)
     #   pymatgen
@@ -208,16 +188,15 @@ msgpack==1.1.1
     # via
     #   bravado
     #   bravado-core
-    #   maggma
     #   mmtf-python
     #   mp-api (pyproject.toml)
-mypy==1.16.1
+mypy==1.17.1
     # via mp-api (pyproject.toml)
 mypy-extensions==1.1.0
     # via
     #   mp-api (pyproject.toml)
     #   mypy
-narwhals==1.43.0
+narwhals==2.1.1
     # via plotly
 networkx==3.5
     # via
@@ -232,7 +211,6 @@ numpy==1.26.4
     #   contourpy
     #   griddataformats
     #   imageio
-    #   maggma
     #   matminer
     #   matplotlib
     #   mdanalysis
@@ -257,16 +235,13 @@ numpy==1.26.4
     #   statsmodels
     #   tidynamics
     #   tifffile
-orjson==3.10.18
-    # via
-    #   maggma
-    #   pymatgen
+orjson==3.11.2
+    # via pymatgen
 packaging==25.0
     # via
     #   lazy-loader
     #   matplotlib
     #   mdanalysis
-    #   mongomock
     #   plotly
     #   pytest
     #   scikit-image
@@ -274,17 +249,14 @@ packaging==25.0
     #   statsmodels
 palettable==3.3.3
     # via pymatgen
-pandas==2.3.0
+pandas==2.3.1
     # via
-    #   maggma
     #   matminer
     #   mpcontribs-client
     #   pymatgen
     #   seaborn
     #   solvation-analysis
     #   statsmodels
-paramiko==3.5.1
-    # via sshtunnel
 parso==0.8.4
     # via jedi
 pathspec==0.12.1
@@ -293,7 +265,7 @@ patsy==1.0.1
     # via statsmodels
 pexpect==4.9.0
     # via ipython
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   imageio
     #   matplotlib
@@ -305,7 +277,7 @@ platformdirs==4.3.8
     # via
     #   pint
     #   virtualenv
-plotly==6.1.2
+plotly==6.3.0
     # via
     #   mpcontribs-client
     #   pymatgen
@@ -314,7 +286,7 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pre-commit==4.2.0
+pre-commit==4.3.0
     # via mp-api (pyproject.toml)
 prompt-toolkit==3.0.51
     # via ipython
@@ -326,34 +298,27 @@ pubchempy==1.0.4
     # via robocrys
 pure-eval==0.2.3
     # via stack-data
-pyarrow==20.0.0
+pyarrow==21.0.0
     # via emmet-core
-pybtex==0.24.0
+pybtex==0.25.1
     # via
     #   emmet-core
     #   robocrys
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via
     #   flake8
     #   mp-api (pyproject.toml)
-pycparser==2.22
-    # via cffi
 pydantic==2.11.7
     # via
     #   emmet-core
-    #   maggma
     #   pydantic-settings
 pydantic-core==2.33.2
     # via pydantic
-pydantic-settings==2.9.1
-    # via
-    #   emmet-core
-    #   maggma
-pydash==8.0.5
-    # via maggma
-pyflakes==3.3.2
+pydantic-settings==2.10.1
+    # via emmet-core
+pyflakes==3.4.0
     # via flake8
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   ipython
     #   ipython-pygments-lexers
@@ -372,31 +337,28 @@ pymatgen==2025.6.14
     #   pymatgen-analysis-defects
     #   pymatgen-analysis-diffusion
     #   robocrys
-pymatgen-analysis-alloys==0.0.7
+pymatgen-analysis-alloys==0.0.8
     # via emmet-core
 pymatgen-analysis-defects==2025.1.18
     # via emmet-core
 pymatgen-analysis-diffusion==2024.7.15
     # via emmet-core
-pymongo==4.10.1
+pymongo==4.14.0
     # via
-    #   maggma
     #   matminer
     #   mpcontribs-client
-pynacl==1.5.0
-    # via paramiko
 pyparsing==3.2.3
     # via
     #   bibtexparser
     #   matplotlib
-pytest==8.4.0
+pytest==8.4.1
     # via
     #   mp-api (pyproject.toml)
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
     #   solvation-analysis
-pytest-asyncio==1.0.0
+pytest-asyncio==1.1.0
     # via mp-api (pyproject.toml)
 pytest-cov==6.2.1
     # via mp-api (pyproject.toml)
@@ -408,15 +370,13 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   bravado
     #   bravado-core
-    #   maggma
     #   matplotlib
     #   pandas
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via pydantic-settings
 pytz==2025.2
     # via
     #   bravado-core
-    #   mongomock
     #   pandas
 pyyaml==6.0.2
     # via
@@ -425,9 +385,7 @@ pyyaml==6.0.2
     #   pre-commit
     #   pybtex
     #   swagger-spec-validator
-pyzmq==27.0.0
-    # via maggma
-rdkit==2025.3.3
+rdkit==2025.3.5
     # via solvation-analysis
 referencing==0.36.2
     # via
@@ -448,30 +406,31 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3986-validator==0.1.1
     # via jsonschema
+rfc3987-syntax==1.1.0
+    # via jsonschema
 robocrys==0.2.11
     # via emmet-core
 roman-numerals-py==3.1.0
     # via sphinx
-rpds-py==0.25.1
+rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
 ruamel-yaml==0.18.14
     # via
     #   custodian
-    #   maggma
     #   monty
     #   pymatgen
     #   robocrys
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 scikit-image==0.25.2
     # via pymatgen-analysis-defects
-scikit-learn==1.7.0
+scikit-learn==1.7.1
     # via matminer
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   ase
     #   griddataformats
@@ -488,8 +447,6 @@ seekpath==2.1.0
     # via emmet-core
 semantic-version==2.10.0
     # via mpcontribs-client
-sentinels==1.0.0
-    # via mongomock
 shapely==2.1.1
     # via pymatgen-analysis-alloys
 simplejson==3.20.1
@@ -501,10 +458,9 @@ six==1.17.0
     #   bravado
     #   bravado-core
     #   flatten-dict
-    #   pybtex
     #   python-dateutil
     #   rfc3339-validator
-smart-open==7.1.0
+smart-open==7.3.0.post1
     # via mp-api (pyproject.toml)
 snowballstemmer==3.0.1
     # via sphinx
@@ -529,11 +485,9 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sshtunnel==0.4.0
-    # via maggma
 stack-data==0.6.3
     # via ipython
-statsmodels==0.14.4
+statsmodels==0.14.5
     # via solvation-analysis
 swagger-spec-validator==3.0.4
     # via
@@ -555,7 +509,6 @@ tifffile==2025.6.11
     # via scikit-image
 tqdm==4.67.1
     # via
-    #   maggma
     #   matminer
     #   mdanalysis
     #   mpcontribs-client
@@ -566,15 +519,15 @@ traitlets==5.14.3
     #   matplotlib-inline
 transport-analysis==0.1.2
     # via emmet-core
-typeguard==4.4.3
+typeguard==4.4.4
     # via inflect
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250809
     # via arrow
-types-requests==2.32.4.20250611
+types-requests==2.32.4.20250809
     # via mp-api (pyproject.toml)
-types-setuptools==80.9.0.20250529
+types-setuptools==80.9.0.20250809
     # via mp-api (pyproject.toml)
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   bravado
     #   emmet-core
@@ -586,7 +539,6 @@ typing-extensions==4.14.0
     #   pint
     #   pydantic
     #   pydantic-core
-    #   pydash
     #   referencing
     #   spglib
     #   swagger-spec-validator
@@ -604,18 +556,18 @@ uncertainties==3.2.3
     # via pymatgen
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.4.0
+urllib3==2.5.0
     # via
     #   botocore
     #   requests
     #   types-requests
-virtualenv==20.31.2
+virtualenv==20.34.0
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==24.11.1
     # via jsonschema
-wrapt==1.17.2
+wrapt==1.17.3
     # via smart-open
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-ubuntu-latest_py3.12.txt
+++ b/requirements/requirements-ubuntu-latest_py3.12.txt
@@ -4,214 +4,126 @@
 #
 #    pip-compile --output-file=requirements/requirements-ubuntu-latest_py3.12.txt pyproject.toml
 #
-aioitertools==0.12.0
-    # via maggma
 annotated-types==0.7.0
     # via pydantic
-attrs==25.3.0
-    # via
-    #   jsonlines
-    #   jsonschema
-    #   referencing
-bcrypt==4.3.0
-    # via paramiko
 bibtexparser==1.4.3
     # via pymatgen
-boto3==1.38.37
-    # via maggma
-botocore==1.38.37
-    # via
-    #   boto3
-    #   s3transfer
-certifi==2025.6.15
+certifi==2025.8.3
     # via requests
-cffi==1.17.1
-    # via
-    #   cryptography
-    #   pynacl
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
-cryptography==45.0.4
-    # via paramiko
 cycler==0.12.1
     # via matplotlib
-dnspython==2.7.0
-    # via
-    #   maggma
-    #   pymongo
-emmet-core==0.84.8
+emmet-core==0.84.9
     # via mp-api (pyproject.toml)
-fonttools==4.58.4
+fonttools==4.59.1
     # via matplotlib
 idna==3.10
     # via requests
-jmespath==1.0.1
-    # via
-    #   boto3
-    #   botocore
 joblib==1.5.1
     # via pymatgen
-jsonlines==4.0.0
-    # via maggma
-jsonschema==4.24.0
-    # via maggma
-jsonschema-specifications==2025.4.1
-    # via jsonschema
-kiwisolver==1.4.8
+kiwisolver==1.4.9
     # via matplotlib
-latexcodec==3.0.0
+latexcodec==3.0.1
     # via pybtex
-maggma==0.71.5
-    # via mp-api (pyproject.toml)
-matplotlib==3.10.3
+matplotlib==3.10.5
     # via pymatgen
-mongomock==4.3.0
-    # via maggma
 monty==2025.3.3
     # via
     #   emmet-core
-    #   maggma
     #   mp-api (pyproject.toml)
     #   pymatgen
 mpmath==1.3.0
     # via sympy
 msgpack==1.1.1
-    # via
-    #   maggma
-    #   mp-api (pyproject.toml)
-narwhals==1.43.0
+    # via mp-api (pyproject.toml)
+narwhals==2.1.1
     # via plotly
 networkx==3.5
     # via pymatgen
-numpy==2.3.0
+numpy==2.3.2
     # via
     #   contourpy
-    #   maggma
     #   matplotlib
     #   monty
     #   pandas
     #   pymatgen
     #   scipy
     #   spglib
-orjson==3.10.18
-    # via
-    #   maggma
-    #   pymatgen
+orjson==3.11.2
+    # via pymatgen
 packaging==25.0
     # via
     #   matplotlib
-    #   mongomock
     #   plotly
 palettable==3.3.3
     # via pymatgen
-pandas==2.3.0
-    # via
-    #   maggma
-    #   pymatgen
-paramiko==3.5.1
-    # via sshtunnel
-pillow==11.2.1
-    # via matplotlib
-plotly==6.1.2
+pandas==2.3.1
     # via pymatgen
-pybtex==0.24.0
+pillow==11.3.0
+    # via matplotlib
+plotly==6.3.0
+    # via pymatgen
+pybtex==0.25.1
     # via emmet-core
-pycparser==2.22
-    # via cffi
 pydantic==2.11.7
     # via
     #   emmet-core
-    #   maggma
     #   pydantic-settings
 pydantic-core==2.33.2
     # via pydantic
-pydantic-settings==2.9.1
-    # via
-    #   emmet-core
-    #   maggma
-pydash==8.0.5
-    # via maggma
+pydantic-settings==2.10.1
+    # via emmet-core
 pymatgen==2025.6.14
     # via
     #   emmet-core
     #   mp-api (pyproject.toml)
-pymongo==4.10.1
-    # via maggma
-pynacl==1.5.0
-    # via paramiko
 pyparsing==3.2.3
     # via
     #   bibtexparser
     #   matplotlib
 python-dateutil==2.9.0.post0
     # via
-    #   botocore
-    #   maggma
     #   matplotlib
     #   pandas
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via pydantic-settings
 pytz==2025.2
-    # via
-    #   mongomock
-    #   pandas
+    # via pandas
 pyyaml==6.0.2
     # via pybtex
-pyzmq==27.0.0
-    # via maggma
-referencing==0.36.2
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.32.4
     # via
     #   mp-api (pyproject.toml)
     #   pymatgen
-rpds-py==0.25.1
-    # via
-    #   jsonschema
-    #   referencing
 ruamel-yaml==0.18.14
     # via
-    #   maggma
     #   monty
     #   pymatgen
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-s3transfer==0.13.0
-    # via boto3
-scipy==1.15.3
+scipy==1.16.1
     # via pymatgen
-sentinels==1.0.0
-    # via mongomock
 six==1.17.0
-    # via
-    #   pybtex
-    #   python-dateutil
-smart-open==7.1.0
+    # via python-dateutil
+smart-open==7.3.0.post1
     # via mp-api (pyproject.toml)
 spglib==2.6.0
     # via pymatgen
-sshtunnel==0.4.0
-    # via maggma
 sympy==1.14.0
     # via pymatgen
 tabulate==0.9.0
     # via pymatgen
 tqdm==4.67.1
-    # via
-    #   maggma
-    #   pymatgen
-typing-extensions==4.14.0
+    # via pymatgen
+typing-extensions==4.14.1
     # via
     #   emmet-core
     #   mp-api (pyproject.toml)
     #   pydantic
     #   pydantic-core
-    #   pydash
-    #   referencing
     #   spglib
     #   typing-inspection
 typing-inspection==0.4.1
@@ -222,11 +134,9 @@ tzdata==2025.2
     # via pandas
 uncertainties==3.2.3
     # via pymatgen
-urllib3==2.4.0
-    # via
-    #   botocore
-    #   requests
-wrapt==1.17.2
+urllib3==2.5.0
+    # via requests
+wrapt==1.17.3
     # via smart-open
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/requirements-ubuntu-latest_py3.12_extras.txt
+++ b/requirements/requirements-ubuntu-latest_py3.12_extras.txt
@@ -4,36 +4,29 @@
 #
 #    pip-compile --all-extras --output-file=requirements/requirements-ubuntu-latest_py3.12_extras.txt pyproject.toml
 #
-aioitertools==0.12.0
-    # via maggma
 alabaster==1.0.0
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
 arrow==1.3.0
     # via isoduration
-ase==3.25.0
+ase==3.26.0
     # via pymatgen-analysis-diffusion
 asttokens==3.0.0
     # via stack-data
 attrs==25.3.0
     # via
-    #   jsonlines
     #   jsonschema
     #   referencing
 babel==2.17.0
     # via sphinx
-bcrypt==4.3.0
-    # via paramiko
 bibtexparser==1.4.3
     # via pymatgen
 boltons==25.0.0
     # via mpcontribs-client
-boto3==1.38.37
-    # via
-    #   maggma
-    #   mp-api (pyproject.toml)
-botocore==1.38.37
+boto3==1.40.9
+    # via mp-api (pyproject.toml)
+botocore==1.40.9
     # via
     #   boto3
     #   s3transfer
@@ -43,48 +36,41 @@ bravado-core==6.1.1
     # via bravado
 cachetools==6.1.0
     # via mpcontribs-client
-certifi==2025.6.15
+certifi==2025.8.3
     # via requests
-cffi==1.17.1
-    # via
-    #   cryptography
-    #   pynacl
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
-coverage[toml]==7.9.1
+coverage[toml]==7.10.3
     # via pytest-cov
-cryptography==45.0.4
-    # via paramiko
-custodian==2025.5.12
+custodian==2025.8.13
     # via mp-api (pyproject.toml)
 cycler==0.12.1
     # via matplotlib
 decorator==5.2.1
     # via ipython
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 dnspython==2.7.0
     # via
-    #   maggma
     #   pyisemail
     #   pymongo
 docutils==0.21.2
     # via sphinx
-emmet-core[all]==0.84.8
+emmet-core[all]==0.84.9
     # via mp-api (pyproject.toml)
 executing==2.2.0
     # via stack-data
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   mdanalysis
     #   virtualenv
 filetype==1.2.0
     # via mpcontribs-client
-flake8==7.2.0
+flake8==7.3.0
     # via mp-api (pyproject.toml)
 flatten-dict==0.4.2
     # via mpcontribs-client
@@ -92,13 +78,13 @@ flexcache==0.3
     # via pint
 flexparser==0.4
     # via pint
-fonttools==4.58.4
+fonttools==4.59.1
     # via matplotlib
 fqdn==1.5.1
     # via jsonschema
 griddataformats==1.0.2
     # via mdanalysis
-identify==2.6.12
+identify==2.6.13
     # via pre-commit
 idna==3.10
     # via
@@ -114,7 +100,7 @@ inflect==7.5.0
     # via robocrys
 iniconfig==2.1.0
     # via pytest
-ipython==9.3.0
+ipython==9.4.0
     # via mpcontribs-client
 ipython-pygments-lexers==1.1.1
     # via ipython
@@ -136,32 +122,29 @@ joblib==1.5.1
     #   scikit-learn
 json2html==1.3.0
     # via mpcontribs-client
-jsonlines==4.0.0
-    # via maggma
 jsonpointer==3.0.0
     # via jsonschema
 jsonref==1.1.0
     # via bravado-core
-jsonschema[format-nongpl]==4.24.0
+jsonschema[format-nongpl]==4.25.0
     # via
     #   bravado-core
-    #   maggma
     #   swagger-spec-validator
 jsonschema-specifications==2025.4.1
     # via jsonschema
-kiwisolver==1.4.8
+kiwisolver==1.4.9
     # via matplotlib
-latexcodec==3.0.0
+lark==1.2.2
+    # via rfc3987-syntax
+latexcodec==3.0.1
     # via pybtex
 lazy-loader==0.4
     # via scikit-image
-maggma==0.71.5
-    # via mp-api (pyproject.toml)
 markupsafe==3.0.2
     # via jinja2
 matminer==0.9.3
     # via robocrys
-matplotlib==3.10.3
+matplotlib==3.10.5
     # via
     #   ase
     #   mdanalysis
@@ -181,15 +164,12 @@ mdanalysis==2.9.0
     #   transport-analysis
 mmtf-python==1.1.3
     # via mdanalysis
-mongomock==4.3.0
-    # via maggma
 monotonic==1.6
     # via bravado
 monty==2025.3.3
     # via
     #   custodian
     #   emmet-core
-    #   maggma
     #   matminer
     #   mp-api (pyproject.toml)
     #   pymatgen
@@ -208,16 +188,15 @@ msgpack==1.1.1
     # via
     #   bravado
     #   bravado-core
-    #   maggma
     #   mmtf-python
     #   mp-api (pyproject.toml)
-mypy==1.16.1
+mypy==1.17.1
     # via mp-api (pyproject.toml)
 mypy-extensions==1.1.0
     # via
     #   mp-api (pyproject.toml)
     #   mypy
-narwhals==1.43.0
+narwhals==2.1.1
     # via plotly
 networkx==3.5
     # via
@@ -232,7 +211,6 @@ numpy==1.26.4
     #   contourpy
     #   griddataformats
     #   imageio
-    #   maggma
     #   matminer
     #   matplotlib
     #   mdanalysis
@@ -257,16 +235,13 @@ numpy==1.26.4
     #   statsmodels
     #   tidynamics
     #   tifffile
-orjson==3.10.18
-    # via
-    #   maggma
-    #   pymatgen
+orjson==3.11.2
+    # via pymatgen
 packaging==25.0
     # via
     #   lazy-loader
     #   matplotlib
     #   mdanalysis
-    #   mongomock
     #   plotly
     #   pytest
     #   scikit-image
@@ -274,17 +249,14 @@ packaging==25.0
     #   statsmodels
 palettable==3.3.3
     # via pymatgen
-pandas==2.3.0
+pandas==2.3.1
     # via
-    #   maggma
     #   matminer
     #   mpcontribs-client
     #   pymatgen
     #   seaborn
     #   solvation-analysis
     #   statsmodels
-paramiko==3.5.1
-    # via sshtunnel
 parso==0.8.4
     # via jedi
 pathspec==0.12.1
@@ -293,7 +265,7 @@ patsy==1.0.1
     # via statsmodels
 pexpect==4.9.0
     # via ipython
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   imageio
     #   matplotlib
@@ -305,7 +277,7 @@ platformdirs==4.3.8
     # via
     #   pint
     #   virtualenv
-plotly==6.1.2
+plotly==6.3.0
     # via
     #   mpcontribs-client
     #   pymatgen
@@ -314,7 +286,7 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-pre-commit==4.2.0
+pre-commit==4.3.0
     # via mp-api (pyproject.toml)
 prompt-toolkit==3.0.51
     # via ipython
@@ -326,34 +298,27 @@ pubchempy==1.0.4
     # via robocrys
 pure-eval==0.2.3
     # via stack-data
-pyarrow==20.0.0
+pyarrow==21.0.0
     # via emmet-core
-pybtex==0.24.0
+pybtex==0.25.1
     # via
     #   emmet-core
     #   robocrys
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via
     #   flake8
     #   mp-api (pyproject.toml)
-pycparser==2.22
-    # via cffi
 pydantic==2.11.7
     # via
     #   emmet-core
-    #   maggma
     #   pydantic-settings
 pydantic-core==2.33.2
     # via pydantic
-pydantic-settings==2.9.1
-    # via
-    #   emmet-core
-    #   maggma
-pydash==8.0.5
-    # via maggma
-pyflakes==3.3.2
+pydantic-settings==2.10.1
+    # via emmet-core
+pyflakes==3.4.0
     # via flake8
-pygments==2.19.1
+pygments==2.19.2
     # via
     #   ipython
     #   ipython-pygments-lexers
@@ -372,31 +337,28 @@ pymatgen==2025.6.14
     #   pymatgen-analysis-defects
     #   pymatgen-analysis-diffusion
     #   robocrys
-pymatgen-analysis-alloys==0.0.7
+pymatgen-analysis-alloys==0.0.8
     # via emmet-core
 pymatgen-analysis-defects==2025.1.18
     # via emmet-core
 pymatgen-analysis-diffusion==2024.7.15
     # via emmet-core
-pymongo==4.10.1
+pymongo==4.14.0
     # via
-    #   maggma
     #   matminer
     #   mpcontribs-client
-pynacl==1.5.0
-    # via paramiko
 pyparsing==3.2.3
     # via
     #   bibtexparser
     #   matplotlib
-pytest==8.4.0
+pytest==8.4.1
     # via
     #   mp-api (pyproject.toml)
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
     #   solvation-analysis
-pytest-asyncio==1.0.0
+pytest-asyncio==1.1.0
     # via mp-api (pyproject.toml)
 pytest-cov==6.2.1
     # via mp-api (pyproject.toml)
@@ -408,15 +370,13 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   bravado
     #   bravado-core
-    #   maggma
     #   matplotlib
     #   pandas
-python-dotenv==1.1.0
+python-dotenv==1.1.1
     # via pydantic-settings
 pytz==2025.2
     # via
     #   bravado-core
-    #   mongomock
     #   pandas
 pyyaml==6.0.2
     # via
@@ -425,9 +385,7 @@ pyyaml==6.0.2
     #   pre-commit
     #   pybtex
     #   swagger-spec-validator
-pyzmq==27.0.0
-    # via maggma
-rdkit==2025.3.3
+rdkit==2025.3.5
     # via solvation-analysis
 referencing==0.36.2
     # via
@@ -448,30 +406,31 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3986-validator==0.1.1
     # via jsonschema
+rfc3987-syntax==1.1.0
+    # via jsonschema
 robocrys==0.2.11
     # via emmet-core
 roman-numerals-py==3.1.0
     # via sphinx
-rpds-py==0.25.1
+rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
 ruamel-yaml==0.18.14
     # via
     #   custodian
-    #   maggma
     #   monty
     #   pymatgen
     #   robocrys
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 scikit-image==0.25.2
     # via pymatgen-analysis-defects
-scikit-learn==1.7.0
+scikit-learn==1.7.1
     # via matminer
-scipy==1.15.3
+scipy==1.16.1
     # via
     #   ase
     #   griddataformats
@@ -488,8 +447,6 @@ seekpath==2.1.0
     # via emmet-core
 semantic-version==2.10.0
     # via mpcontribs-client
-sentinels==1.0.0
-    # via mongomock
 shapely==2.1.1
     # via pymatgen-analysis-alloys
 simplejson==3.20.1
@@ -501,10 +458,9 @@ six==1.17.0
     #   bravado
     #   bravado-core
     #   flatten-dict
-    #   pybtex
     #   python-dateutil
     #   rfc3339-validator
-smart-open==7.1.0
+smart-open==7.3.0.post1
     # via mp-api (pyproject.toml)
 snowballstemmer==3.0.1
     # via sphinx
@@ -529,11 +485,9 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sshtunnel==0.4.0
-    # via maggma
 stack-data==0.6.3
     # via ipython
-statsmodels==0.14.4
+statsmodels==0.14.5
     # via solvation-analysis
 swagger-spec-validator==3.0.4
     # via
@@ -555,7 +509,6 @@ tifffile==2025.6.11
     # via scikit-image
 tqdm==4.67.1
     # via
-    #   maggma
     #   matminer
     #   mdanalysis
     #   mpcontribs-client
@@ -566,15 +519,15 @@ traitlets==5.14.3
     #   matplotlib-inline
 transport-analysis==0.1.2
     # via emmet-core
-typeguard==4.4.3
+typeguard==4.4.4
     # via inflect
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250809
     # via arrow
-types-requests==2.32.4.20250611
+types-requests==2.32.4.20250809
     # via mp-api (pyproject.toml)
-types-setuptools==80.9.0.20250529
+types-setuptools==80.9.0.20250809
     # via mp-api (pyproject.toml)
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   bravado
     #   emmet-core
@@ -585,7 +538,6 @@ typing-extensions==4.14.0
     #   pint
     #   pydantic
     #   pydantic-core
-    #   pydash
     #   referencing
     #   spglib
     #   swagger-spec-validator
@@ -603,18 +555,18 @@ uncertainties==3.2.3
     # via pymatgen
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.4.0
+urllib3==2.5.0
     # via
     #   botocore
     #   requests
     #   types-requests
-virtualenv==20.31.2
+virtualenv==20.34.0
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
 webcolors==24.11.1
     # via jsonschema
-wrapt==1.17.2
+wrapt==1.17.3
     # via smart-open
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
*Can be merged once `emmet-core` [#1267](https://github.com/materialsproject/emmet/pull/1267) is merged/released.*

Migrates sole `maggma` import to `emmet.core`, removes `maggma` from dependencies.