### PR TITLE
[WIP] Compatibility with emmet 0.85.0

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -718,6 +718,7 @@ class MPRester:
 
         if additional_criteria:
             input_params = {**input_params, **additional_criteria}
+        print(input_params)
 
         entries = []
 
@@ -1341,7 +1342,7 @@ class MPRester:
         decoder = MontyDecoder().decode if self.monty_decode else json.loads
         kwargs = dict(
             bucket="materialsproject-parsed",
-            key=f"chgcars/{str(task_id)}.json.gz",
+            key=f"chgcars/{validate_ids([task_id])[0]}.json.gz",
             decoder=decoder,
         )
         chgcar = self.materials.tasks._query_open_data(**kwargs)[0]

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -12,7 +12,7 @@ from emmet.core.electronic_structure import BSPathType
 from emmet.core.mpid import MPID
 from emmet.core.settings import EmmetSettings
 from emmet.core.tasks import TaskDoc
-from emmet.core.thermo import ThermoType
+from emmet.core.types.enums import ThermoType
 from emmet.core.vasp.calc_types import CalcType
 from monty.json import MontyDecoder
 from packaging import version

--- a/mp_api/client/routes/materials/electronic_structure.py
+++ b/mp_api/client/routes/materials/electronic_structure.py
@@ -237,7 +237,7 @@ class BandStructureRester(BaseRester):
         decoder = MontyDecoder().decode if self.monty_decode else json.loads
         result = self._query_open_data(
             bucket="materialsproject-parsed",
-            key=f"bandstructures/{task_id}.json.gz",
+            key=f"bandstructures/{validate_ids([task_id])[0]}.json.gz",
             decoder=decoder,
         )[0]
 
@@ -433,7 +433,7 @@ class DosRester(BaseRester):
         decoder = MontyDecoder().decode if self.monty_decode else json.loads
         result = self._query_open_data(
             bucket="materialsproject-parsed",
-            key=f"dos/{task_id}.json.gz",
+            key=f"dos/{validate_ids([task_id])[0]}.json.gz",
             decoder=decoder,
         )[0]
 

--- a/mp_api/client/routes/materials/thermo.py
+++ b/mp_api/client/routes/materials/thermo.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections import defaultdict
 
 import numpy as np
-from emmet.core.thermo import ThermoDoc, ThermoType
+from emmet.core.thermo import ThermoDoc
+from emmet.core.types.enums import ThermoType
 from monty.json import MontyDecoder
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.core import Element

--- a/mp_api/client/routes/materials/xas.py
+++ b/mp_api/client/routes/materials/xas.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
-from emmet.core.xas import Edge, Type, XASDoc
+from typing import TYPE_CHECKING
+
+from emmet.core.xas import XASDoc
 from pymatgen.core.periodic_table import Element
 
 from mp_api.client.core import BaseRester
 from mp_api.client.core.utils import validate_ids
+
+if TYPE_CHECKING:
+    from emmet.core.types.enums import XasEdge, XasType
 
 
 class XASRester(BaseRester[XASDoc]):
@@ -14,13 +19,13 @@ class XASRester(BaseRester[XASDoc]):
 
     def search(
         self,
-        edge: Edge | None = None,
+        edge: XasEdge | None = None,
         absorbing_element: Element | None = None,
         formula: str | None = None,
         chemsys: str | list[str] | None = None,
         elements: list[str] | None = None,
         material_ids: list[str] | None = None,
-        spectrum_type: Type | None = None,
+        spectrum_type: XasType | None = None,
         spectrum_ids: str | list[str] | None = None,
         num_chunks: int | None = None,
         chunk_size: int = 1000,
@@ -30,7 +35,7 @@ class XASRester(BaseRester[XASDoc]):
         """Query core XAS docs using a variety of search criteria.
 
         Arguments:
-            edge (Edge): The absorption edge (e.g. K, L2, L3, L2,3).
+            edge (XasEdge): The absorption edge (e.g. K, L2, L3, L2,3).
             absorbing_element (Element): The absorbing element.
             formula (str): A formula including anonymized formula
                 or wild cards (e.g., Fe2O3, ABO3, Si*).
@@ -39,7 +44,7 @@ class XASRester(BaseRester[XASDoc]):
             elements (List[str]): A list of elements.
             material_ids (str, List[str]): A single Material ID string or list of strings
                 (e.g., mp-149, [mp-149, mp-13]).
-            spectrum_type (Type): Spectrum type (e.g. EXAFS, XAFS, or XANES).
+            spectrum_type (XasType): Spectrum type (e.g. EXAFS, XAFS, or XANES).
             spectrum_ids (str, List[str]): A single Spectrum ID string or list of strings
                 (e.g., mp-149-XANES-Li-K, [mp-149-XANES-Li-K, mp-13-XANES-Li-K]).
             num_chunks (int): Maximum number of chunks of data to yield. None will yield all possible.

--- a/tests/materials/test_thermo.py
+++ b/tests/materials/test_thermo.py
@@ -2,7 +2,7 @@ import os
 from core_function import client_search_testing
 
 import pytest
-from emmet.core.thermo import ThermoType
+from emmet.core.types.enums import ThermoType
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 
 from mp_api.client.routes.materials.thermo import ThermoRester

--- a/tests/materials/test_xas.py
+++ b/tests/materials/test_xas.py
@@ -2,7 +2,7 @@ import os
 from core_function import client_search_testing
 
 import pytest
-from emmet.core.xas import Edge, Type
+from emmet.core.types.enums import XasEdge, XasType
 from pymatgen.core.periodic_table import Element
 
 from mp_api.client.routes.materials.xas import XASRester
@@ -33,8 +33,8 @@ alt_name_dict = {
 }  # type: dict
 
 custom_field_tests = {
-    "edge": Edge.L2_3,
-    "spectrum_type": Type.EXAFS,
+    "edge": XasEdge.L2_3,
+    "spectrum_type": XasType.EXAFS,
     "absorbing_element": Element("Ce"),
     "required_elements": [Element("Ce")],
     "formula": "Ce(WO4)2",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -93,4 +93,7 @@ def test_generic_get_methods(rester):
             docs = getattr(rester, search_method)(
                 **{key + "s": [key_only_resters[name]]}, fields=[key]
             )
+            with pytest.warns(DeprecationWarning, match="get_data_by_id is deprecated"):
+                _ = rester.get_data_by_id(key_only_resters[name], fields=[key])
+
             assert docs_check(docs)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,6 +67,10 @@ def test_generic_get_methods(rester):
         use_document_model=True,
     )
 
+    docs_check = lambda _docs: all(
+        rester.document_model.__module__ == _doc.__module__ for _doc in _docs
+    )
+
     if name not in ignore_generic:
         key = rester.primary_key
         if name not in key_only_resters:
@@ -74,12 +78,19 @@ def test_generic_get_methods(rester):
                 key = rester.available_fields[0]
 
             doc = rester._query_resource_data({"_limit": 1}, fields=[key])[0]
-            assert isinstance(doc, rester.document_model)
+            assert docs_check([doc])
 
             if name not in search_only_resters:
-                doc = rester.get_data_by_id(doc.model_dump()[key], fields=[key])
-                assert isinstance(doc, rester.document_model)
+                docs = rester.search(
+                    **{key + "s": [doc.model_dump()[key]]}, fields=[key]
+                )
+                assert docs_check(docs)
 
         elif name not in special_resters:
-            doc = rester.get_data_by_id(key_only_resters[name], fields=[key])
-            assert isinstance(doc, rester.document_model)
+            search_method = "search"
+            if name == "materials_robocrys":
+                search_method += "_docs"
+            docs = getattr(rester, search_method)(
+                **{key + "s": [key_only_resters[name]]}, fields=[key]
+            )
+            assert docs_check(docs)

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -303,7 +303,7 @@ class TestMPRester:
             "mp-149", inc_task_doc=True
         )
         assert isinstance(chgcar, Chgcar)
-        assert isinstance(task_doc, TaskDoc)
+        assert isinstance(TaskDoc.model_validate(task_doc.model_dump()), TaskDoc)
 
     def test_get_charge_density_from_task_id(self, mpr):
         chgcar = mpr.get_charge_density_from_task_id("mp-2246557")
@@ -313,7 +313,7 @@ class TestMPRester:
             "mp-2246557", inc_task_doc=True
         )
         assert isinstance(chgcar, Chgcar)
-        assert isinstance(task_doc, TaskDoc)
+        assert isinstance(TaskDoc.model_validate(task_doc.model_dump()), TaskDoc)
 
     def test_get_wulff_shape(self, mpr):
         ws = mpr.get_wulff_shape("mp-126")
@@ -480,6 +480,7 @@ class TestMPRester:
                 ]
 
             if no_compound_entries:
+                print(mpr.get_stability(modified_entries, thermo_type=thermo_type))
                 with pytest.warns(UserWarning, match="No phase diagram data available"):
                     mpr.get_stability(modified_entries, thermo_type=thermo_type)
                 return

--- a/tests/test_mprester.py
+++ b/tests/test_mprester.py
@@ -6,7 +6,7 @@ import importlib
 import numpy as np
 import pytest
 from emmet.core.tasks import TaskDoc
-from emmet.core.thermo import ThermoType
+from emmet.core.types.enums import ThermoType
 from emmet.core.vasp.calc_types import CalcType
 from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.analysis.pourbaix_diagram import IonEntry, PourbaixDiagram, PourbaixEntry


### PR DESCRIPTION
Changes related to the coming `emmet-core==0.85.0` [release](https://github.com/materialsproject/emmet/pull/1294):
- Compatibility with AlphaID and the new `SuffixedID` classes in thermo, insertion electrodes, and XAS
- Using `emmet-core`'s ID validation to handle checking of user-input identifiers (across MPID, AlphaID, SuffixedID)
- Removed `api_sanitize` so that loading `MPRester()` does not change the underlying emmet models (the previous behavior)
- Modified `MPDataDoc` construction to not inherit directly from the emmet model (would require modifying them in place to make required fields optional) but to inherit the typing / validation options from them