### PR TITLE
setuptools is not needed at runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  "setuptools",
   "msgpack",
   "maggma>=0.57.1",
   "pymatgen>=2022.3.7,!=2024.2.20",


### PR DESCRIPTION
Dear Maintainers,

We are slowly trying to remove the legacy runtime of `setuptools` from Debian

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1083669

This is not obvious if you don't know Debian's `dh-python` build system
that translate the `setuptools` dependency into the `python3-pk-resources` runtime.
.... this is not even obvious to most Debian contributors 😅