### PR TITLE
Support for querying symmetry information by lists

### DIFF
--- a/mp_api/client/routes/materials/summary.py
+++ b/mp_api/client/routes/materials/summary.py
@@ -81,7 +81,7 @@ class SummaryRester(BaseRester[SummaryDoc]):
             band_gap (Tuple[float,float]): Minimum and maximum band gap in eV to consider.
             chemsys (str, List[str]): A chemical system or list of chemical systems
                 (e.g., Li-Fe-O, Si-*, [Si-O, Li-Fe-P]).
-            crystal_system (CrystalSystem): Crystal system of material.
+            crystal_system (CrystalSystem or list[CrystalSystem]): Crystal system(s) of the materials.
             density (Tuple[float,float]): Minimum and maximum density to consider.
             deprecated (bool): Whether the material is tagged as deprecated.
             e_electronic (Tuple[float,float]): Minimum and maximum electronic dielectric constant to consider.
@@ -128,8 +128,8 @@ class SummaryRester(BaseRester[SummaryDoc]):
             poisson_ratio (Tuple[float,float]): Minimum and maximum value to consider for Poisson's ratio.
             possible_species (List(str)): List of element symbols appended with oxidation states. (e.g. Cr2+,O2-)
             shape_factor (Tuple[float,float]): Minimum and maximum shape factor values to consider.
-            spacegroup_number (int): Space group number of material.
-            spacegroup_symbol (str): Space group symbol of the material in international short symbol notation.
+            spacegroup_number (int or list[int]): Space group number(s) of materials.
+            spacegroup_symbol (str or list[str]): Space group symbol(s) of the materials in international short symbol notation.
             surface_energy_anisotropy (Tuple[float,float]): Minimum and maximum surface energy anisotropy values
                 to consider.
             theoretical: (bool): Whether the material is theoretical.

--- a/tests/materials/test_summary.py
+++ b/tests/materials/test_summary.py
@@ -96,6 +96,13 @@ def test_list_like_input():
         doc.material_id for doc in docs_by_number
     }
 
+    # also chosen for very low document count
+    crys_sys = ["Hexagonal", "Cubic"]
+    assert {
+        doc.symmetry.crystal_system
+        for doc in search_method(elements=["Ar"], crystal_system=crys_sys)
+    } == set(crys_sys)
+
     # should fail - we don't support querying by so many list values
     with pytest.raises(ValueError, match="retrieve all data first and then filter"):
         _ = search_method(spacegroup_number=list(range(1, 231)))


### PR DESCRIPTION
Closes [#902](https://github.com/materialsproject/api/issues/902): Support for querying summary data by lists of space group numbers/symbols, or by lists of crystal systems, was already added to the API but not included in the client.

Updates this to allow users to query by a list of `spacegroup_symbol`, `spacegroup_number`, or `crystal_system`, up to a list of length half the cardinality of those (caps of 114, 114, and 2 entries per list, respectively).

