### PR TITLE
chore: add orjson to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "emmet-core>=0.84.6rc0",
   "smart_open",
   "boto3",
+  "orjson >= 3.10,<4",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

`orjson` is installed via the indirect dependency of `pymatgen` (since v2025.5.28 https://github.com/materialsproject/pymatgen/pull/4411).

However, current `mp-api` allows users to use the older versions of `pymatgen`, which do not depend on `orjson`, which causes a runtime error after installation.

https://github.com/materialsproject/api/blob/7d509363812bdb81b9ac4fac693e4db6b8e71250/pyproject.toml#L24

Given the situation, I think we have two options: (1) increasing the minimum version of pymatgen or (2) add `orjson` to dependency of mp-api. I think it would be better to adopt (2) since `orjson` is actually used in the mp-api codebase (even if installing `orjson` by increasing the minimum version of `pymatgen`, that is *indirectly* installed. I think the dependency should be declared explicitly).

---

## How to replicate the issue

This problem happens when third-party package depends on the specific version of pymatgen, and any version of mp-api.

```
# use old pymatgen (e.g. third-party package depends on the specific version of pymatgen, and any version of mp-api)
> uv pip install 'pymatgen<v2025.4.16' mp-api
Resolved 56 packages in 531ms
      Built pymatgen==2025.4.10
Prepared 1 package in 12.19s
Installed 56 packages in 368ms
 + annotated-types==0.7.0
 + blake3==1.0.8
 + boto3==1.40.52
 + botocore==1.40.52
 + certifi==2025.10.5
 ...
 + spglib==2.6.0
 + sympy==1.14.0
 + tabulate==0.9.0
 + tqdm==4.67.1
 + typing-extensions==4.15.0
 + typing-inspection==0.4.2
 + tzdata==2025.2
 + uncertainties==3.2.3
 + urllib3==2.5.0
 + wrapt==1.17.3

> uv run python -c 'from mp_api.client import MPRester'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from mp_api.client import MPRester
  File "/Users/himkt/Desktop/tmp-proj/.venv/lib/python3.13/site-packages/mp_api/client/__init__.py", line 7, in <module>
    from .core import MPRestError
  File "/Users/himkt/Desktop/tmp-proj/.venv/lib/python3.13/site-packages/mp_api/client/core/__init__.py", line 3, in <module>
    from .client import BaseRester, MPRestError, MPRestWarning
  File "/Users/himkt/Desktop/tmp-proj/.venv/lib/python3.13/site-packages/mp_api/client/core/client.py", line 41, in <module>
    from mp_api.client.core.utils import load_json, validate_ids
  File "/Users/himkt/Desktop/tmp-proj/.venv/lib/python3.13/site-packages/mp_api/client/core/utils.py", line 6, in <module>
    import orjson
ModuleNotFoundError: No module named 'orjson'
```