### PR TITLE
[WIP] Similarity search with vector search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "typing-extensions>=3.7.4.1",
   "requests>=2.23.0",
   "monty>=2024.12.10",
-  "emmet-core>=0.85.1rc0",
+  "emmet-core>=0.86.2rc1",
   "smart_open",
   "boto3",
   "orjson >= 3.10,<4",
@@ -33,7 +33,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-all = ["emmet-core[all]>=0.85.1rc0", "custodian", "mpcontribs-client>=5.10"]
+all = ["emmet-core[all]>=0.86.2rc1", "custodian", "mpcontribs-client>=5.10"]
 test = [
   "pre-commit",
   "pytest",

--- a/requirements/requirements-ubuntu-latest_py3.11.txt
+++ b/requirements/requirements-ubuntu-latest_py3.11.txt
@@ -24,7 +24,7 @@ contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-emmet-core==0.86.2rc0
+emmet-core==0.86.2rc1
     # via mp-api (pyproject.toml)
 fonttools==4.60.1
     # via matplotlib

--- a/requirements/requirements-ubuntu-latest_py3.11_extras.txt
+++ b/requirements/requirements-ubuntu-latest_py3.11_extras.txt
@@ -62,7 +62,7 @@ dnspython==2.8.0
     #   pymongo
 docutils==0.21.2
     # via sphinx
-emmet-core[all]==0.86.2rc0
+emmet-core[all]==0.86.2rc1
     # via mp-api (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist

--- a/requirements/requirements-ubuntu-latest_py3.12.txt
+++ b/requirements/requirements-ubuntu-latest_py3.12.txt
@@ -24,7 +24,7 @@ contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-emmet-core==0.86.2rc0
+emmet-core==0.86.2rc1
     # via mp-api (pyproject.toml)
 fonttools==4.60.1
     # via matplotlib

--- a/requirements/requirements-ubuntu-latest_py3.12_extras.txt
+++ b/requirements/requirements-ubuntu-latest_py3.12_extras.txt
@@ -62,7 +62,7 @@ dnspython==2.8.0
     #   pymongo
 docutils==0.21.2
     # via sphinx
-emmet-core[all]==0.86.2rc0
+emmet-core[all]==0.86.2rc1
     # via mp-api (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist


### PR DESCRIPTION
Adds `find_similar` method to `SimilarityRester` to leverage Atlas vector search on the updated similarity collection. Requires [emmet #1347](https://github.com/materialsproject/emmet/pull/1347)