### PR TITLE
Skip some tests if optional deps not installed

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -370,8 +370,8 @@ class MPRester:
                 self._contribs = None
                 warnings.warn(
                     "mpcontribs-client not installed. "
-                    "Install the package to query MPContribs data, or construct pourbaix diagrams: "
-                    "'pip install mpcontribs-client'"
+                    "Install the package to query MPContribs data, construct pourbaix diagrams, "
+                    "or to compute cohesive energies: 'pip install mpcontribs-client'"
                 )
             except Exception as error:
                 self._contribs = None

--- a/tests/materials/test_alloys.py
+++ b/tests/materials/test_alloys.py
@@ -2,6 +2,14 @@ import os
 
 import pytest
 
+try:
+    import pymatgen.analysis.alloys
+except ImportError:
+    pytest.skip(
+        "Please `pip install pymatgen-analysis-alloys` to use the `materials.alloys` endpoint",
+        allow_module_level=True,
+    )
+
 from mp_api.client.routes.materials.alloys import AlloysRester
 
 from ..conftest import client_search_testing, requires_api_key


### PR DESCRIPTION
- Skip tests which rely on optional modules if those modules are not installed:
  - similarity: needs `matminer` for feature vector search
  - alloys: needs `pymatgen-analysis-alloys`
  - `MPRester`: needs `mpcontribs-client` for pourbaix and cohesive energy functionality
- Re-enable pourbaix tests