### PR TITLE
[BREAKING] Change default thermo type in get_entries_in_chemsys

### DIFF
--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -1093,7 +1093,7 @@ class MPRester:
 
         if additional_criteria is None:
             warnings.warn(
-                "The default thermo type in retrieving entries has been changed from "
+                "The default thermo type when retrieving entries has been changed from "
                 "the mixed/corrected PBE GGA and GGA+U hull (`thermo_type = GGA_GGA+U`) "
                 "to the joint PBE GGA / GGA+U / r2SCAN hull (`thermo_type = GGA_GGA+U_R2SCAN`). "
                 "To use the older behavior, call `get_entries_in_chemsys` with "

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 
     from mp_api.client.core.client import _DictLikeAccess
 
-DEFAULT_THERMOTYPE_CRITERIA = {"thermo_types": ["GGA_GGA+U"]}
+DEFAULT_THERMOTYPE_CRITERIA = {"thermo_types": ["GGA_GGA+U_R2SCAN"]}
 
 RESTER_LAYOUT = {
     "molecules/core": LazyImport(
@@ -1032,7 +1032,7 @@ class MPRester:
         compatible_only: bool = True,
         property_data: list[str] | None = None,
         conventional_unit_cell: bool = False,
-        additional_criteria: dict = DEFAULT_THERMOTYPE_CRITERIA,
+        additional_criteria: dict | None = None,
         **kwargs,
     ) -> list[ComputedStructureEntry] | list[GibbsComputedStructureEntry]:
         """Helper method to get a list of ComputedEntries in a chemical system.
@@ -1090,6 +1090,17 @@ class MPRester:
             for i in range(len(elements_set))
             for els in itertools.combinations(elements_set, i + 1)
         ]
+
+        if additional_criteria is None:
+            warnings.warn(
+                "The default thermo type in retrieving entries has been changed from "
+                "the mixed/corrected PBE GGA and GGA+U hull (`thermo_type = GGA_GGA+U`) "
+                "to the joint PBE GGA / GGA+U / r2SCAN hull (`thermo_type = GGA_GGA+U_R2SCAN`). "
+                "To use the older behavior, call `get_entries_in_chemsys` with "
+                '`additional_criteria = {"thermo_types": ["GGA_GGA+U"]}`',
+                category=MPRestWarning,
+                stacklevel=2,
+            )
 
         entries = self.get_entries(
             all_chemsyses,

--- a/tests/client/test_mprester.py
+++ b/tests/client/test_mprester.py
@@ -260,7 +260,10 @@ loop_
     def test_get_entries_in_chemsys(self, mpr):
         syms = ["Li", "Fe", "O"]
         syms2 = "Li-Fe-O"
-        entries = mpr.get_entries_in_chemsys(syms)
+        with pytest.warns(
+            MPRestWarning, match="The default thermo type when retrieving entries"
+        ):
+            entries = mpr.get_entries_in_chemsys(syms)
         entries2 = mpr.get_entries_in_chemsys(syms2)
         elements = {Element(sym) for sym in syms}
         for e in entries:
@@ -325,7 +328,9 @@ loop_
         reason="`pip install mpcontribs-client` to use pourbaix functionality.",
     )
     def test_get_ion_entries(self, mpr):
-        entries = mpr.get_entries_in_chemsys("Ti-O-H")
+        entries = mpr.get_entries_in_chemsys(
+            "Ti-O-H", additional_criteria={"thermo_types": ["GGA_GGA+U"]}
+        )
         pd = PhaseDiagram(entries)
         ion_entry_data = mpr.get_ion_reference_data_for_chemsys("Ti-O-H")
         ion_entries = mpr.get_ion_entries(pd, ion_entry_data)
@@ -337,7 +342,9 @@ loop_
         assert len(bi_v_entry_data) == len(bi_data + v_data)
 
         # test an incomplete phase diagram
-        entries = mpr.get_entries_in_chemsys("Ti-O")
+        entries = mpr.get_entries_in_chemsys(
+            "Ti-O", additional_criteria={"thermo_types": ["GGA_GGA+U"]}
+        )
         pd = PhaseDiagram(entries)
         with pytest.raises(ValueError, match="The phase diagram chemical system"):
             mpr.get_ion_entries(pd)
@@ -351,7 +358,8 @@ loop_
             itertools.chain.from_iterable(i.elements for i in ion_ref_comps)
         )
         ion_ref_entries = mpr.get_entries_in_chemsys(
-            [*map(str, ion_ref_elts), "O", "H"]
+            [*map(str, ion_ref_elts), "O", "H"],
+            additional_criteria={"thermo_types": ["GGA_GGA+U"]},
         )
         mpc = MaterialsProjectAqueousCompatibility()
         ion_ref_entries = mpc.process_entries(ion_ref_entries)


### PR DESCRIPTION
Closes [#993](https://github.com/materialsproject/api/issues/993) by defaulting to the `GGA_GGA+U_R2SCAN` hull as the default thermo type. This is consistent with our website's behavior and will be more relevant as we start building in the recompute data