### PR TITLE
Defer non-core pymatgen analysis imports in MPRester

### DIFF
--- a/mp_api/client/core/_oxygen_evolution.py
+++ b/mp_api/client/core/_oxygen_evolution.py
@@ -7,16 +7,19 @@ import warnings
 from collections.abc import Sequence
 from io import StringIO
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import requests
-from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.core import Composition, Element
 from scipy.constants import Avogadro, Boltzmann, atm, elementary_charge
 from scipy.interpolate import make_splrep, splev
 
 from mp_api.client.core.exceptions import MPRestWarning
+
+if TYPE_CHECKING:
+    from pymatgen.analysis.phase_diagram import PhaseDiagram
 
 DEFAULT_CACHE_FILE = Path(__file__).absolute().parent / "JANAF_O2_data.json"
 # O2 partial pressure at ambient conditions, in MPa

--- a/mp_api/client/mprester.py
+++ b/mp_api/client/mprester.py
@@ -12,8 +12,6 @@ from emmet.core.mpid import MPID, AlphaID
 from emmet.core.types.enums import ThermoType
 from emmet.core.vasp.calc_types import CalcType
 from packaging import version
-from pymatgen.analysis.phase_diagram import PhaseDiagram
-from pymatgen.analysis.pourbaix_diagram import IonEntry
 from pymatgen.core import Composition, Element, Structure
 from pymatgen.core.ion import Ion
 from pymatgen.entries.computed_entries import ComputedStructureEntry
@@ -47,8 +45,8 @@ if TYPE_CHECKING:
     import numpy as np
     from emmet.core.tasks import CoreTaskDoc
     from packaging.version import Version
-    from pymatgen.analysis.phase_diagram import PDEntry
-    from pymatgen.analysis.pourbaix_diagram import PourbaixEntry
+    from pymatgen.analysis.phase_diagram import PDEntry, PhaseDiagram
+    from pymatgen.analysis.pourbaix_diagram import IonEntry, PourbaixEntry
     from pymatgen.entries.compatibility import Compatibility
     from pymatgen.entries.computed_entries import (
         ComputedEntry,
@@ -717,6 +715,7 @@ class MPRester:
             list of PourbaixEntry
         """
         # imports are not top-level due to expense
+        from pymatgen.analysis.phase_diagram import PhaseDiagram
         from pymatgen.analysis.pourbaix_diagram import PourbaixEntry
         from pymatgen.entries.compatibility import (
             Compatibility,
@@ -949,6 +948,8 @@ class MPRester:
             [IonEntry]: IonEntry are similar to PDEntry objects. Their energies
                 are free energies in eV.
         """
+        from pymatgen.analysis.pourbaix_diagram import IonEntry
+
         # determine the chemsys from the phase diagram
         chemsys = "-".join([el.symbol for el in pd.elements])
 
@@ -1570,6 +1571,8 @@ class MPRester:
         entries: list[ComputedEntry | ComputedStructureEntry | PDEntry],
         thermo_type: str | ThermoType = ThermoType.GGA_GGA_U,
     ) -> list[dict[str, Any]] | None:
+        from pymatgen.analysis.phase_diagram import PhaseDiagram
+
         chemsys: set[SpeciesLike] = {
             ele for entry in entries for ele in entry.composition.elements
         }

--- a/mp_api/client/routes/materials/thermo.py
+++ b/mp_api/client/routes/materials/thermo.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 import numpy as np
 from emmet.core.thermo import ThermoDoc
 from emmet.core.types.enums import ThermoType
-from pymatgen.analysis.phase_diagram import PhaseDiagram
 from pymatgen.core import Element
 from pymatgen.core import __version__ as __pmg_version__
 
 from mp_api.client.core import BaseRester
 from mp_api.client.core.utils import load_json, validate_ids
+
+if TYPE_CHECKING:
+    from pymatgen.analysis.phase_diagram import PhaseDiagram
 
 
 class ThermoRester(BaseRester):
@@ -156,6 +159,8 @@ class ThermoRester(BaseRester):
         Returns:
             (PhaseDiagram): Pymatgen phase diagram object.
         """
+        from pymatgen.analysis.phase_diagram import PhaseDiagram
+
         t_type = thermo_type if isinstance(thermo_type, str) else thermo_type.value
         valid_types = {*map(str, ThermoType.__members__.values())}
         if invalid_types := {t_type} - valid_types:


### PR DESCRIPTION
## Summary

After the `pymatgen` / `pymatgen-core` split, the `pymatgen-core` wheel ships the `pymatgen` namespace package, but `phase_diagram`, `pourbaix_diagram`, `chempot_diagram`, and `reaction_calculator` live only in the full `pymatgen` wheel. Several `mp_api.client` modules import `pymatgen.analysis.phase_diagram` / `pymatgen.analysis.pourbaix_diagram` at module top level, so `import mp_api.client` crashes with `ModuleNotFoundError` whenever the full `pymatgen` wheel isn't on the path — for example after a packaging install order that leaves `pymatgen-core` resolved but not the non-core analysis modules. The failure reproduces today with a clean install of `pymatgen==2026.5.4` + `pymatgen-core==2026.4.16` + `mp-api==0.46.1`:

```
ModuleNotFoundError: No module named 'pymatgen.analysis.phase_diagram'
  File ".../mp_api/client/mprester.py", line 15, in <module>
    from pymatgen.analysis.phase_diagram import PhaseDiagram
```

This PR moves those imports to either `TYPE_CHECKING` blocks (annotation-only references — `from __future__ import annotations` is already active everywhere touched) or function-body lazy imports (runtime constructions). The pattern matches what `get_pourbaix_entries` already does for `PourbaixEntry`, `MaterialsProject2020Compatibility`, and friends.

This is a step toward the request in #1098 — `mp-api` no longer pulls non-core `pymatgen` modules during `import mp_api.client`. It does *not* fully drop the runtime dependency: the lazy imports still need the symbols to exist when the relevant methods (`get_pourbaix_entries`, `get_ion_entries`, `get_stability`, `get_phase_diagram_from_chemsys`, `OxygenEvolution.get_oxygen_evolution_from_phase_diagram`) are actually called. But the surface area shrinks from "every import of `mp_api.client`" to "only the methods that actually need a `PhaseDiagram`."

Related: #1098

## Changes

| File | Change |
|---|---|
| `mp_api/client/mprester.py` | Drop top-level `PhaseDiagram` / `IonEntry` imports; add to `TYPE_CHECKING`; defer to `get_pourbaix_entries`, `get_ion_entries`, `get_stability`. |
| `mp_api/client/core/_oxygen_evolution.py` | `PhaseDiagram` is annotation-only — move to `TYPE_CHECKING`. |
| `mp_api/client/routes/materials/thermo.py` | Defer `PhaseDiagram` to `get_phase_diagram_from_chemsys`; annotation moved to `TYPE_CHECKING`. |

No public-API change. No behavior change when the full `pymatgen` wheel is available.

## Test plan

- [x] `import mp_api.client` succeeds with `pymatgen-core` installed but `pymatgen.analysis.phase_diagram` missing (the failure mode this PR fixes).
- [ ] CI passes the existing `mp_api` test suite (full `pymatgen` available — should be a no-op since lazy imports resolve the same symbols at the same call sites).
- [ ] Manual smoke: `MPRester().get_pourbaix_entries(...)`, `get_stability(...)`, and `materials.thermo.get_phase_diagram_from_chemsys(...)` still work end-to-end with a real API key.