### PR TITLE
Check for many contributions to warn of potential OOM and clarify use…

### DIFF
--- a/mp_api/client/contribs/client.py
+++ b/mp_api/client/contribs/client.py
@@ -1914,7 +1914,7 @@ class ContribsClient(SwaggerClient):
         during an update.
 
         It is possible to quickly run Out Of Memory in the case of large/many contributions.
-        It is recommended to chunk your uploads to a reasonable size based on your machine capabilties
+        It is recommended to chunk your uploads to a reasonable size based on your machine capabilities
         and contribution size.
 
         Args:

--- a/mp_api/client/contribs/client.py
+++ b/mp_api/client/contribs/client.py
@@ -1913,9 +1913,13 @@ class ContribsClient(SwaggerClient):
         updating. Set list entries to `None` for components that are to be left untouched
         during an update.
 
+        It is possible to quickly run Out Of Memory in the case of large/many contributions.
+        It is recommended to chunk your uploads to a reasonable size based on your machine capabilties
+        and contribution size.
+
         Args:
             contributions (list): list of contribution dicts to submit
-            ignore_dupes (bool): force duplicate components to be submitted
+            ignore_dupes (bool): force duplicate components to be submitted. If your contributions intentionally share components, set this to True.
             timeout (int): cancel remaining requests if timeout exceeded (in seconds)
             skip_dupe_check (bool): skip duplicate check for contribution identifiers
 
@@ -1925,9 +1929,14 @@ class ContribsClient(SwaggerClient):
         Raises:
             MPContribsClientError on malformed submitted data.
         """
-        if not contributions or not isinstance(contributions, list):
+        if not contributions:
             raise MPContribsClientError(
                 "Please provide list of contributions to submit."
+            )
+        many_contribs_flag = 5000
+        if len(contributions) > many_contribs_flag:
+            MPCC_LOGGER.warning(
+                msg=f"Large number of contributions detected (>{many_contribs_flag}). OOM may occur. Batching recommended."
             )
 
         # get existing contributions


### PR DESCRIPTION
# Summary
Leo found that our ```submit_contributions``` client method needed to be clearer in documentation.

> 1. No recommended batch size for submit_contributions. On a big dataset it's easy to OOM, since the whole batch gets held in memory on the client side. I hit an out-of-memory kill trying to submit all ~16.5k at once, and fixed it just by chunking into batches of 500. Might be worth a note in the docstring about a sane batch size, or a warning when the batch is large.
> 2. A single duplicate aborts the entire upload. If any component is a duplicate, submit_contributions raises and kills the whole batch. In my case a handful of my systems relaxed to byte-identical structures (different starting configs, same DFT minimum), which is legit data — so the whole run died on it. Would be nicer to skip/warn on dupes and keep going by default.
> For reference (mpcontribs-client __init__.py):
> 
> the raise is at line 2345, guarded byif not ignore_dupes and dupe:at 2343
> there's even a# TODO add matching duplicate info to msgat 2344 — the message doesn't say _which_ contribution it collides with, which made it a bit of a hunt to track down
> I did findignore_dupes/skip_dupe_check(params at 2120/2122) which solve it, but they weren't obvious — maybe worth surfacing in the docs, or flipping skip-and-warn to the default

# Changes
- Added paragraph to docstring warning about the need to batch due to potential OOM errors
-  Log warning if contribs list is larger than an arbitrary number (I chose 5,000)
    - This could be based on byte-size of the contribs list[dict] that gets passed in